### PR TITLE
Forge fmt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        # with:
-        #   version: nightly
 
       - name: Show Forge version
         run: |


### PR DESCRIPTION
- remove nightly for forge fmt in CI
- use ubuntu as default matrix for CI