### PR TITLE
Audit findings

### DIFF
--- a/src/issuance/TANIssuanceHistory.sol
+++ b/src/issuance/TANIssuanceHistory.sol
@@ -26,6 +26,7 @@ contract TANIssuanceHistory is Ownable {
     error InvalidAddress(address invalidAddress);
     error InvalidBlock(uint256 endBlock);
     error FutureLookup(uint256 queriedBlock, uint48 clockBlock);
+    error IncreaseClaimableByFailed(address account, uint256 amount);
 
     struct IssuanceReward {
         address account;
@@ -116,7 +117,8 @@ contract TANIssuanceHistory is Ownable {
         tel.approve(address(plugin), totalAmount);
         for (uint256 i; i < len; ++i) {
             // event emission on this contract is omitted since the plugin emits a `ClaimableIncreased` event
-            plugin.increaseClaimableBy(rewards[i].account, rewards[i].amount);
+            bool success = plugin.increaseClaimableBy(rewards[i].account, rewards[i].amount);
+            if (!success) revert IncreaseClaimableByFailed(rewards[i].account, rewards[i].amount);
         }
     }
 

--- a/src/issuance/TANIssuanceHistory.sol
+++ b/src/issuance/TANIssuanceHistory.sol
@@ -23,6 +23,7 @@ contract TANIssuanceHistory is Ownable {
     using SafeERC20 for IERC20;
 
     error ERC6372InconsistentClock();
+    error IncompatiblePlugin();
     error InvalidAddress(address invalidAddress);
     error InvalidBlock(uint256 endBlock);
     error FutureLookup(uint256 queriedBlock, uint48 clockBlock);
@@ -124,8 +125,8 @@ contract TANIssuanceHistory is Ownable {
 
     /// @dev Permissioned function to set a new issuance plugin
     function setTanIssuancePlugin(ISimplePlugin newPlugin) external onlyOwner {
-        if (address(newPlugin) == address(0x0) || address(newPlugin).code.length == 0) {
-            revert InvalidAddress(address(newPlugin));
+        if (newPlugin.tel() != tel) {
+            revert IncompatiblePlugin();
         }
         tanIssuancePlugin = newPlugin;
     }

--- a/src/issuance/TANIssuanceHistory.sol
+++ b/src/issuance/TANIssuanceHistory.sol
@@ -116,7 +116,7 @@ contract TANIssuanceHistory is Ownable {
         if (endBlock > block.number) revert InvalidBlock(endBlock);
         lastSettlementBlock = endBlock;
 
-        uint256 totalAmount;
+        uint256 totalAmount = 0;
         uint256 len = rewards.length;
         for (uint256 i; i < len; ++i) {
             uint256 amount = rewards[i].amount;

--- a/src/issuance/TANIssuanceHistory.sol
+++ b/src/issuance/TANIssuanceHistory.sol
@@ -113,11 +113,12 @@ contract TANIssuanceHistory is Ownable {
             _incrementCumulativeRewards(rewards[i].account, amount, endBlock);
         }
 
-        // set approval as `SimplePlugin::increaseClaimableBy()` pulls TEL from this address to itself
-        tel.approve(address(tanIssuancePlugin), totalAmount);
+        // cache plugin in memory, set approval as `SimplePlugin::increaseClaimableBy()` pulls TEL from this address
+        ISimplePlugin plugin = tanIssuancePlugin;
+        tel.approve(address(plugin), totalAmount);
         for (uint256 i; i < len; ++i) {
             // event emission on this contract is omitted since the plugin emits a `ClaimableIncreased` event
-            tanIssuancePlugin.increaseClaimableBy(rewards[i].account, rewards[i].amount);
+            plugin.increaseClaimableBy(rewards[i].account, rewards[i].amount);
         }
     }
 

--- a/src/issuance/TANIssuanceHistory.sol
+++ b/src/issuance/TANIssuanceHistory.sol
@@ -121,7 +121,7 @@ contract TANIssuanceHistory is Ownable {
             if (amounts[i] == 0) continue;
 
             totalAmount += amounts[i];
-            _incrementCumulativeRewards(accounts[i], amounts[i]);
+            _incrementCumulativeRewards(accounts[i], amounts[i], endBlock);
         }
 
         // set approval as `SimplePlugin::increaseClaimableBy()` pulls TEL from this address to itself
@@ -170,11 +170,11 @@ contract TANIssuanceHistory is Ownable {
     /**
      * Internals
      */
-    function _incrementCumulativeRewards(address account, uint256 amount) internal {
+    function _incrementCumulativeRewards(address account, uint256 amount, uint256 endBlock) internal {
         uint256 prevCumulativeReward = cumulativeRewards(account);
         uint224 newCumulativeReward = SafeCast.toUint224(prevCumulativeReward + amount);
 
-        _cumulativeRewards[account].push(uint32(block.number), newCumulativeReward);
+        _cumulativeRewards[account].push(SafeCast.toUint32(endBlock), newCumulativeReward);
     }
 
     /// @dev Validate that user-supplied block is in the past, and return it as a uint48.

--- a/src/issuance/TANIssuanceHistory.sol
+++ b/src/issuance/TANIssuanceHistory.sol
@@ -106,11 +106,8 @@ contract TANIssuanceHistory is Ownable {
         uint256 totalAmount = 0;
         uint256 len = rewards.length;
         for (uint256 i; i < len; ++i) {
-            uint256 amount = rewards[i].amount;
-            if (amount == 0) continue;
-
-            totalAmount += amount;
-            _incrementCumulativeRewards(rewards[i].account, amount, endBlock);
+            totalAmount += rewards[i].amount;
+            _incrementCumulativeRewards(rewards[i].account, rewards[i].amount, endBlock);
         }
 
         // cache plugin in memory, set approval as `SimplePlugin::increaseClaimableBy()` pulls TEL from this address

--- a/src/issuance/TANIssuanceHistory.sol
+++ b/src/issuance/TANIssuanceHistory.sol
@@ -100,7 +100,8 @@ contract TANIssuanceHistory is Ownable {
 
     /// @dev Saves the settlement block, updates cumulative rewards history, and settles TEL rewards on the plugin
     function increaseClaimableByBatch(IssuanceReward[] calldata rewards, uint256 endBlock) external onlyOwner {
-        if (endBlock > block.number) revert InvalidBlock(endBlock);
+        // ensure temporal ordering of reward settlements
+        if (endBlock < lastSettlementBlock || endBlock > block.number) revert InvalidBlock(endBlock);
         lastSettlementBlock = endBlock;
 
         uint256 totalAmount = 0;

--- a/test/issuance/TANIssuanceHistoryForkTest.t.sol
+++ b/test/issuance/TANIssuanceHistoryForkTest.t.sol
@@ -34,8 +34,7 @@ contract TANIssuanceHistoryForkTest is Test {
     uint256 issuanceAmount;
     uint256 scalingFactor;
     uint256 totalEligibleVolume;
-    address[] rewardees;
-    uint256[] rewards;
+    TANIssuanceHistory.IssuanceReward[] rewards;
     uint256 endBlock;
 
     function setUp() public {
@@ -108,8 +107,7 @@ contract TANIssuanceHistoryForkTest is Test {
         if (userRewardCap < userReward) userReward = userRewardCap;
 
         // once calculated, construct distribution calldata
-        rewardees.push(user);
-        rewards.push(userReward);
+        rewards.push(TANIssuanceHistory.IssuanceReward(user, userReward));
         endBlock = block.number;
 
         // distribute rewards (funds come from TAN safe)
@@ -122,7 +120,7 @@ contract TANIssuanceHistoryForkTest is Test {
 
         // owner of TANIssuanceHistory contract is configured as TAN safe
         vm.prank(tanSafe);
-        tanIssuanceHistory.increaseClaimableByBatch(rewardees, rewards, endBlock);
+        tanIssuanceHistory.increaseClaimableByBatch(rewards, endBlock);
 
         // asserts
         assertEq(tel.balanceOf(address(tanIssuanceHistory)), 0);

--- a/test/issuance/TANIssuanceHistoryTest.t.sol
+++ b/test/issuance/TANIssuanceHistoryTest.t.sol
@@ -69,7 +69,7 @@ contract TANIssuanceHistoryTest is Test {
         TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](2);
 
         vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(TANIssuanceHistory.Deactivated.selector));
+        vm.expectRevert(abi.encodeWithSelector(MockPlugin.Deactivated.selector));
         tanIssuanceHistory.increaseClaimableByBatch(rewards, block.number);
     }
 

--- a/test/issuance/TANIssuanceHistoryTest.t.sol
+++ b/test/issuance/TANIssuanceHistoryTest.t.sol
@@ -43,57 +43,43 @@ contract TANIssuanceHistoryTest is Test {
     /// @dev Useful as a benchmark for the maximum batch size which is ~15000 users
     function testFuzz_increaseClaimableByBatch(uint16 numUsers) public {
         numUsers = uint16(bound(numUsers, 0, 14_000));
-        address[] memory accounts = new address[](numUsers);
-        uint256[] memory amounts = new uint256[](numUsers);
+
+        TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](numUsers);
         for (uint256 i; i < numUsers; ++i) {
-            accounts[i] = address(uint160(uint256(numUsers) + i));
-            amounts[i] = uint256(numUsers) + i;
+            rewards[i].account = address(uint160(uint256(numUsers) + i));
+            rewards[i].amount = uint256(numUsers) + i;
         }
 
         vm.prank(owner); // Ensure the caller is the owner
         uint256 someBlock = block.number + 5;
         vm.roll(someBlock);
-        tanIssuanceHistory.increaseClaimableByBatch(accounts, amounts, someBlock);
+        tanIssuanceHistory.increaseClaimableByBatch(rewards, someBlock);
 
         for (uint256 i; i < numUsers; ++i) {
-            assertEq(tanIssuanceHistory.cumulativeRewards(accounts[i]), amounts[i]);
+            assertEq(tanIssuanceHistory.cumulativeRewards(rewards[i].account), rewards[i].amount);
         }
 
         assertEq(tanIssuanceHistory.lastSettlementBlock(), someBlock);
-    }
-
-    function testIncreaseClaimableByBatchRevertArityMismatch() public {
-        address[] memory accounts = new address[](2);
-        uint256[] memory amounts = new uint256[](1);
-
-        vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(TANIssuanceHistory.ArityMismatch.selector));
-        tanIssuanceHistory.increaseClaimableByBatch(accounts, amounts, block.number);
     }
 
     function testIncreaseClaimableByBatchWhenDeactivated() public {
         // Mock the plugin to return deactivated
         MockPlugin(address(mockPlugin)).setDeactivated(true);
 
-        address[] memory accounts = new address[](1);
-        uint256[] memory amounts = new uint256[](1);
+        TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](2);
 
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(TANIssuanceHistory.Deactivated.selector));
-        tanIssuanceHistory.increaseClaimableByBatch(accounts, amounts, block.number);
+        tanIssuanceHistory.increaseClaimableByBatch(rewards, block.number);
     }
 
     function testCumulativeRewardsAtBlock() public {
+        TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](2);
+        rewards[0] = TANIssuanceHistory.IssuanceReward(user1, 100);
+        rewards[1] = TANIssuanceHistory.IssuanceReward(user2, 200);
+
         vm.prank(owner);
-        address[] memory accounts = new address[](2);
-        accounts[0] = user1;
-        accounts[1] = user2;
-
-        uint256[] memory amounts = new uint256[](2);
-        amounts[0] = 100;
-        amounts[1] = 200;
-
-        tanIssuanceHistory.increaseClaimableByBatch(accounts, amounts, block.number);
+        tanIssuanceHistory.increaseClaimableByBatch(rewards, block.number);
 
         // Move forward in blocks
         vm.roll(block.number + 10);
@@ -102,11 +88,14 @@ contract TANIssuanceHistoryTest is Test {
         assertEq(tanIssuanceHistory.cumulativeRewardsAtBlock(user2, block.number - 10), 200);
 
         uint256 queryBlock = block.number - 10;
-        (address[] memory users, uint256[] memory rewards) =
+        address[] memory accounts = new address[](2);
+        accounts[0] = user1;
+        accounts[1] = user2;
+        (address[] memory users, uint256[] memory returnedRewards) =
             tanIssuanceHistory.cumulativeRewardsAtBlockBatched(accounts, queryBlock);
         for (uint256 i; i < users.length; ++i) {
-            assertEq(users[i], accounts[i]);
-            assertEq(rewards[i], amounts[i]);
+            assertEq(rewards[i].account, accounts[i]);
+            assertEq(returnedRewards[i], rewards[i].amount);
         }
     }
 
@@ -152,12 +141,9 @@ contract TANIssuanceHistoryTest is Test {
         if (referrerRewardCap < referrerReward) referrerReward = referrerRewardCap;
 
         // once calculated, construct distribution calldata
-        address[] memory rewardees = new address[](2);
-        rewardees[0] = user;
-        rewardees[1] = referrer;
-        uint256[] memory rewards = new uint256[](2);
-        rewards[0] = userReward;
-        rewards[1] = referrerReward;
+        TANIssuanceHistory.IssuanceReward[] memory rewards = new TANIssuanceHistory.IssuanceReward[](2);
+        rewards[0] = TANIssuanceHistory.IssuanceReward(user, userReward);
+        rewards[1] = TANIssuanceHistory.IssuanceReward(referrer, referrerReward);
         uint256 endBlock = block.number;
 
         // pre-settlement sanity asserts
@@ -167,7 +153,7 @@ contract TANIssuanceHistoryTest is Test {
 
         // settle distribution of rewards
         vm.prank(owner);
-        tanIssuanceHistory.increaseClaimableByBatch(rewardees, rewards, endBlock);
+        tanIssuanceHistory.increaseClaimableByBatch(rewards, endBlock);
 
         assertEq(tanIssuanceHistory.lastSettlementBlock(), endBlock);
         assertEq(tanIssuanceHistory.cumulativeRewards(user), userReward);

--- a/test/issuance/mocks/MockImplementations.sol
+++ b/test/issuance/mocks/MockImplementations.sol
@@ -83,6 +83,8 @@ contract MockStakingModule {
 
 /// @notice  This contract did not need to be deployed for testing as one already exists
 contract MockPlugin is ISimplePlugin {
+    error Deactivated();
+
     bool public deactivated;
     IERC20 public tel;
     uint256 public totalClaimable;
@@ -97,6 +99,8 @@ contract MockPlugin is ISimplePlugin {
     }
 
     function increaseClaimableBy(address account, uint256 amount) external override returns (bool) {
+        if (deactivated) revert Deactivated();
+        
         // simplified mock implementation
         claimable[account] += amount;
         return true;

--- a/test/issuance/mocks/MockImplementations.sol
+++ b/test/issuance/mocks/MockImplementations.sol
@@ -100,7 +100,7 @@ contract MockPlugin is ISimplePlugin {
 
     function increaseClaimableBy(address account, uint256 amount) external override returns (bool) {
         if (deactivated) revert Deactivated();
-        
+
         // simplified mock implementation
         claimable[account] += amount;
         return true;


### PR DESCRIPTION
Backwards compatible & minor fixes for Cantina audit

## Finding 6: Gas Optimizations
These optimizations increase the maximum number of accounts we can reward before hitting out of gas errors, so we would be able to handle more eligible TANIP-1 program participants.
1. commit e9fc684 removes unnecessary zero amount checks
2. commit 594d3c1 caches plugin to memory from storage
3. commit 4bbec8d removes redundant `whenNotDeactivated` modifier
5. commit e414b13 improves safe typecasting readability in view functions
6. commit 2f7c34b replaces calldata arrays with a single calldata array of new `IssuanceReward` struct

## Finding 4: Reduce chance of owner error in setting new plugin
Likelihood of the owner providing a wrong plugin is low however calling the owner-provided plugin for its `tel()` provides utter certainty that owner provided correct address
- commit d970896 checks the owner-provided plugin for its `tel()` address

## Finding 3: Set forward-looking best practice by explicitly capturing + validating plugin's boolean return value
Capturing & validating the return value from `SimplePlugin::increaseClaimableBy()` is not relevant to this implementation since false only occurs on 0 amounts which are filtered out by the backend (and the history contract previous to commit e9fc684), but setting a best practice for other `Increaser` contracts we may implement in the future
- commit a8100d3 makes use of the plugin's returned boolean value as a best practice

## Finding 2: Document chronological settlement order 
The history contract's OZ Checkpoints dependency enforces chronological settlement order, but that behavior is not readily visible at the top level and requires developers to delve into the inheritance tree. A comment documenting this behavior is helpful.
- commit e62c390 adds a comment and includes an explicit check for clarity

## Finding 1: Address timestamp recording inaccuracy by using provided `endBlock` parameter rather than `block.number`
At settlement time the `increaseClaimableByBatch()` function was storing a checkpoint using the current block number as a map key rather than the specified `endBlock`. This had no impact on the program or the `StakerIncentivesCalculator` because when deriving rewards caps, previous cumulative rewards are obtained simply by searching for the most recent checkpoint. Timestamps (the checkpoint's stored block number) do not need to be accurate as for a cumulative amount only the most recent entry's value is relevant. However, timestamps should be stored accurately.
- commit 1060bb3 brings the `endBlock` parameter through the relevant internal function and uses it rather than `block.number`