### PR TITLE
2: Add single epoch delay for unstake eligibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Below, we follow the general lifecycle of a new validator in roughly chronologic
 
 5. **Exit Requests**: Active validators may choose to retire by calling the `exit()` function, which places them in the exit queue where they remain active and eligible for selection in voter committees until their exit is finalized.
 
-6. - **Protocol-Determined Exit**: The protocol manages exit finalization. A validator is fully exited after being excluded from voter committees for two consecutive epochs.
+6. - **Protocol-Determined Exit**: The protocol manages exit finalization. A validator is fully exited after being excluded from voter committees for two consecutive epochs handled at the epoch boundary during the `concludeEpoch()` system call. This is a permissioned transition of the validator from `PendingExit` to `Exited` status, at which point the validator becomes eligible for unstaking after waiting one additional epoch.
 
-7. **Unstaking**: Validators or their delegators must call the `unstake()` function in the `Exited` state to reclaim the original stake and any accrued rewards. This process burns the `ConsensusNFT`, releasing the stake and rewards. Once unstaked, the validator's address enters an `UNSTAKED` state, making the retirement irreversible. To rejoin the network, a new `ConsensusNFT` must be obtained, and a new validator address must be used.
+7. **Unstaking**: Validators that have elapsed one full epoch in the `Exited` state (or their delegators) may call the `unstake()` function to reclaim the original stake and any accrued rewards. This process burns the `ConsensusNFT`, releasing the stake and rewards. Once unstaked, the validator's address enters an `UNSTAKED` state, making the retirement irreversible. To rejoin the network, a new `ConsensusNFT` must be obtained, and a new validator address must be used.
 
 This detailed lifecycle ensures that validators are properly integrated into the Telcoin Network, maintaining the integrity and reliability of the network's consensus mechanism. For further technical details, refer to the [consensus/design.md](./design.md) file.
 

--- a/src/consensus/invariants.md
+++ b/src/consensus/invariants.md
@@ -18,6 +18,7 @@
 - pending activation and pending exit validators are also considered active since exit queue is updated before checking committee size
 - exit from the pending exit queue is determined solely by the protocol, which determines a queued validator may exit by excluding it from the committee across 3 epochs
 - unless forcibly burned, only Exited or Staked validators can unstake, ie: Exited to Retired, or Staked to Any (unstaking pre-activation bypasses activation)
+- after reaching Exited status requirement, validators must wait an additional epoch to unstake
 - retired validator addresses can never rejoin
 - validators are only eligible for rewards at the completion of their first full epoch
 - unvariant: validator storage vector can eventually grow to exceed gas limits but this will be a good problem to have and storage can be optimized

--- a/src/interfaces/IConsensusRegistry.sol
+++ b/src/interfaces/IConsensusRegistry.sol
@@ -47,6 +47,7 @@ interface IConsensusRegistry {
     error InvalidStatus(ValidatorStatus status);
     error InvalidEpoch(uint32 epoch);
     error InvalidDuration(uint32 duration);
+    error IneligibleUnstake(ValidatorInfo validator);
 
     event ValidatorStaked(ValidatorInfo validator);
     event ValidatorPendingActivation(ValidatorInfo validator);


### PR DESCRIPTION
To smooth out the validator lifecycle's timeline for offboarding, this PR adds a required one epoch delay for validators in `Exited` status to become eligible for unstaking. This also grants the rust protocol even more flexibility wrt slashing by extending validator slashability by one epoch.