### PR TITLE
40: Bypass external calls to recipients during burns and final slashes

### DIFF
--- a/src/interfaces/IStakeManager.sol
+++ b/src/interfaces/IStakeManager.sol
@@ -102,7 +102,7 @@ interface IStakeManager {
     function issuance() external view returns (address payable);
 
     /// @dev Returns staking information for the given address
-    function getBalance(address validatorAddress) external view returns (uint256);
+    function getBalanceBreakdown(address validatorAddress) external view returns (uint256, uint256, uint256);
 
     /// @dev Returns the current version
     function getCurrentStakeVersion() external view returns (uint8);

--- a/test/consensus/ConsensusRegistryTest.t.sol
+++ b/test/consensus/ConsensusRegistryTest.t.sol
@@ -43,7 +43,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             EpochInfo memory info = consensusRegistry.getEpochInfo(uint32(i));
             for (uint256 j; j < 4; ++j) {
                 assertEq(info.committee[j], initialValidators[j].validatorAddress);
-                assertEq(consensusRegistry.getBalance(initialValidators[j].validatorAddress), stakeAmount_);
+                (uint256 balance,,) = consensusRegistry.getBalanceBreakdown(initialValidators[j].validatorAddress);
+                assertEq(balance, stakeAmount_);
             }
         }
 


### PR DESCRIPTION
Avoids potential reverts that could be introduced by a malicious or pwned delegator contract during the `_consensusBurn()` flow by bypassing external calls to recipients during burns or final slashes. This is clean since no funds are due to recipients after confiscation during burns and final slashes. 

It does leave the potential for the aforementioned delegator reverts during reward claims via `_claimStakeRewards()`, however because reward claims are pull-based actions only, any such reverts would be entirely self-induced and affects only the malicious delegator themselves.