### PR TITLE
Add third chain demonstration to clarify Axelar options

### DIFF
--- a/deployments/Deployments.sol
+++ b/deployments/Deployments.sol
@@ -21,6 +21,7 @@ struct Deployments {
     address admin;
     EXYZs eXYZs;
     ITS its;
+    address optimismTEL;
     address sepoliaTEL;
     UniswapV2 uniswapV2;
     address wTEL;

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -57,6 +57,7 @@
     "TokenManagerImpl": "0x5683C518fB0A39Cdc3EEBc0E03B968F108AC9916",
     "TokenManagerDeployer": "0x1Eb942ca2ADC970E43eBb40e94E0118eAA2EDC16"
   },
+  "optimismTEL": "0x8CFb42a80291737Cb62cEF7B665Fe1304D112Fee",
   "sepoliaTEL": "0x92bc9f0D42A3194Df2C5AB55c3bbDD82e6Fb2F92",
   "uniswapV2": {
     "UniswapV2Factory": "0x764eca68a03ff1eb710e7d1a02c2e7c008877f2f",

--- a/deployments/utils/ITSConfig.sol
+++ b/deployments/utils/ITSConfig.sol
@@ -31,7 +31,11 @@ abstract contract ITSConfig is ITSUtils {
     uint256 constant SEPOLIA_CHAINID = 11155111;
     string constant DEVNET_TN_CHAIN_NAME = "telcoin";
     bytes32 constant DEVNET_TN_CHAINNAMEHASH = keccak256(bytes(DEVNET_TN_CHAIN_NAME));
-    bytes32 constant DEVNET_INTERCHAIN_TOKENID = 0x09f3c6e8754c8e269060f138d8b55526b0058b0fa258f90ae3197ee4808d23b6;
+    bytes32 constant DEVNET_INTERCHAIN_TOKENID = 0x7da21a183d41d57607078acf0ae8c42a61f1613ab223509359da7d27b95bc1f5;
+    string constant DEVNET_OPTIMISM_CHAIN_NAME = "optimism-sepolia";
+    bytes32 constant DEVNET_OPTIMISM_CHAINNAMEHASH = keccak256(bytes(DEVNET_OPTIMISM_CHAIN_NAME));
+    address constant DEVNET_OPTIMISM_ITS = 0x2269B93c8D8D4AfcE9786d2940F5Fcd4386Db7ff;
+    address constant DEVNET_OPTIMISM_GATEWAY = 0xF128c84c3326727c3e155168daAa4C0156B87AD1;
     string constant DEVNET_SEPOLIA_CHAIN_NAME = "eth-sepolia";
     bytes32 constant DEVNET_SEPOLIA_CHAINNAMEHASH = 0x24f78f6b35533491ef3d467d5e8306033cca94049b9b76db747dfc786df43f86;
     address constant DEVNET_SEPOLIA_ITS = 0x2269B93c8D8D4AfcE9786d2940F5Fcd4386Db7ff;
@@ -58,6 +62,12 @@ abstract contract ITSConfig is ITSUtils {
     InterchainTokenService sepoliaITS;
     InterchainTokenFactory sepoliaITF;
     AxelarAmplifierGateway sepoliaGateway;
+    // Optimism Sepolia
+    IERC20 optimismTEL;
+    InterchainTokenService optimismITS;
+    InterchainTokenFactory optimismITF;
+    AxelarAmplifierGateway optimismGateway;
+    ITokenManagerType.TokenManagerType optimismTELTMType = ITokenManagerType.TokenManagerType.MINT_BURN;
 
     uint256 public constant telTotalSupply = 100_000_000_000e18;
     /// @dev TEL genesis allocation to the governance safe for gas used to relay initial ITS bridging

--- a/test/ITS/ITSTestHelper.sol
+++ b/test/ITS/ITSTestHelper.sol
@@ -71,8 +71,10 @@ abstract contract ITSTestHelper is Test, TNGenesis {
         customLinkedTokenId = ITSUtils.instantiateInterchainTEL(sepoliaIts).interchainTokenId();
 
         // note that TN must be added as a trusted chain to the Ethereum ITS contract
-        vm.prank(sepoliaITS.owner());
+        vm.startPrank(sepoliaITS.owner());
         sepoliaITS.setTrustedAddress(DEVNET_TN_CHAIN_NAME, ITS_HUB_ROUTING_IDENTIFIER);
+        sepoliaITS.setTrustedAddress(DEVNET_OPTIMISM_CHAIN_NAME, ITS_HUB_ROUTING_IDENTIFIER);
+        vm.stopPrank();
     }
 
     /// @notice Test utility for deploying ITS architecture, including InterchainTEL and its TokenManager, via create3
@@ -196,6 +198,31 @@ abstract contract ITSTestHelper is Test, TNGenesis {
         originTELTokenManager = TokenManager(iTEL.tokenManagerAddress());
         customLinkedTokenId = iTEL.interchainTokenId();
         instantiateInterchainTELTokenManager(address(its), customLinkedTokenId);
+    }
+
+    function setUp_optimismFork_devnetConfig(
+        address linker_,
+        address optimismTel,
+        address optimismIts,
+        address optimismItf
+    )
+        internal
+    {
+        linker = linker_;
+        vm.deal(linker, 1 ether);
+        tmOperator = AddressBytes.toBytes(linker);
+        gasValue = 0.001 ether;
+        optimismTEL = IERC20(optimismTel);
+        optimismITS = InterchainTokenService(optimismIts);
+        optimismITF = InterchainTokenFactory(optimismItf);
+        optimismGateway = AxelarAmplifierGateway(DEVNET_OPTIMISM_GATEWAY);
+        owner_ = address(linker); // will be used to set tmOperator
+
+        // note that origin chain must be added as a trusted chain to the destination ITS contract
+        vm.startPrank(optimismITS.owner());
+        optimismITS.setTrustedAddress(DEVNET_SEPOLIA_CHAIN_NAME, ITS_HUB_ROUTING_IDENTIFIER);
+        optimismITS.setTrustedAddress(ITS_HUB_CHAIN_NAME, ITS_HUB_ROUTING_IDENTIFIER);
+        vm.stopPrank();
     }
 
     /// @dev Assert correctness of origin ITS return values against TN contracts


### PR DESCRIPTION
Adds a third chain to the custom token linking fork test, demonstrating that Axelar's custom linked tokenID schema supports multiple instances of either MINT_BURN && LOCK_RELEASE token managers. This is in direct contradiction to their documentation, which appears to be outdated and based only on the canonical token ID schema.

Based on discussions, use of `MINT_BURN` token manager with a "newTEL" token upgraded from "oldTEL" in place on Base & Polygon is more desirable.

Link test notes:
- Axelar amplifier devnet does not support Base or Polygon, so "optimism-sepolia" was chosen as the closest standin. 
- The fork test for linking has also been extended to a fuzz test to fuzz between both token manager types.
