### PR TITLE
Harden epoch info ring buffers with epoch ID

### DIFF
--- a/src/consensus/ConsensusRegistry.sol
+++ b/src/consensus/ConsensusRegistry.sol
@@ -65,7 +65,7 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         ValidatorInfo[] memory newActive = _getValidators(ValidatorStatus.Active);
         _checkCommitteeSize(newActive.length, futureCommittee.length);
 
-        emit NewEpoch(EpochInfo(newCommittee, issuance, uint64(block.number + 1), duration, stakeVersion));
+        emit NewEpoch(EpochInfo(newCommittee, issuance, uint64(block.number + 1), newEpoch, duration, stakeVersion));
     }
 
     /// @inheritdoc IConsensusRegistry
@@ -496,7 +496,13 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
     }
 
     /// @notice Spends `blsPubkey`. Must be an externally validated G2 point in 96-byte compressed form
-    function _spendBLSPubkey(bytes memory blsPubkey, address validatorAddress) private returns (bytes32 blsPubkeyHash) {
+    function _spendBLSPubkey(
+        bytes memory blsPubkey,
+        address validatorAddress
+    )
+        private
+        returns (bytes32 blsPubkeyHash)
+    {
         blsPubkeyHash = keccak256(blsPubkey);
         if (blsPubkeyHashToValidator[blsPubkeyHash] != address(0)) revert DuplicateBLSPubkey();
         blsPubkeyHashToValidator[blsPubkeyHash] = validatorAddress;
@@ -693,21 +699,23 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         uint8 newEpochPointer = (prevEpochPointer + 1) % 4;
 
         // update new current epoch info
+        epochPointer = newEpochPointer;
+        uint32 newEpoch = ++currentEpoch;
         address[] storage newCommittee = futureEpochInfo[newEpochPointer].committee;
         StakeConfig memory newStakeConfig = getCurrentStakeConfig();
         epochInfo[newEpochPointer] = EpochInfo(
             newCommittee,
             newStakeConfig.epochIssuance,
             uint64(block.number) + 1,
+            newEpoch,
             newStakeConfig.epochDuration,
             stakeVersion
         );
-        epochPointer = newEpochPointer;
-        uint32 newEpoch = ++currentEpoch;
 
         // update future epoch info
         uint8 twoEpochsInFuturePointer = (newEpochPointer + 2) % 4;
         futureEpochInfo[twoEpochsInFuturePointer].committee = futureCommittee;
+        futureEpochInfo[twoEpochsInFuturePointer].epochId = newEpoch + 2;
 
         return (newEpoch, newStakeConfig.epochIssuance, newStakeConfig.epochDuration, newCommittee);
     }
@@ -724,7 +732,10 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         returns (EpochInfo storage)
     {
         uint8 futurePointer = (uint8(future - current) + currentPointer) % 4;
-        return futureEpochInfo[futurePointer];
+        EpochInfo storage info = futureEpochInfo[futurePointer];
+        if (info.epochId != future) revert InvalidEpoch(future);
+
+        return info;
     }
 
     /// @dev Fetch info for a current or past epoch; four latest are stored (current and three in past)
@@ -741,7 +752,11 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         uint8 pointerDiff = uint8(current - recent);
         // prevent underflow by adding 4 (will be modulo'd away)
         uint8 pointer = (4 + currentPointer - pointerDiff) % 4;
-        return epochInfo[pointer];
+
+        EpochInfo storage info = epochInfo[pointer];
+        if (info.epochId != recent) revert InvalidEpoch(recent);
+
+        return info;
     }
 
     function _enforceSorting(address[] calldata futureCommittee) internal pure {
@@ -765,7 +780,14 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
     }
 
     /// @dev Returns whether given `validatorAddress` is a member of the given committee
-    function _isCommitteeMember(address validatorAddress, address[] memory committee) internal pure returns (bool) {
+    function _isCommitteeMember(
+        address validatorAddress,
+        address[] memory committee
+    )
+        internal
+        pure
+        returns (bool)
+    {
         // cache len to memory
         uint256 committeeLen = committee.length;
         for (uint256 i; i < committeeLen; ++i) {
@@ -885,12 +907,20 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         // NOTE: committees are expected to always be < 100
         nextCommitteeSize = uint16(initialValidators_.length);
 
+        // set first three epochs with genesis config
         for (uint256 j; j <= 2; ++j) {
             EpochInfo storage epoch = epochInfo[j];
+            epoch.epochId = uint32(j);
             epoch.epochDuration = genesisConfig_.epochDuration;
             epoch.epochIssuance = genesisConfig_.epochIssuance;
+
+            EpochInfo storage futureEpoch = futureEpochInfo[j]; //todo
+            futureEpoch.epochId = uint32(j);
+            futureEpoch.epochDuration = genesisConfig_.epochDuration;
+            futureEpoch.epochIssuance = genesisConfig_.epochIssuance;
         }
 
+        // set initial validators
         for (uint256 i; i < initialValidators_.length; ++i) {
             ValidatorInfo memory currentValidator = initialValidators_[i];
             bytes32 blsPubkeyHash = _verifyProofOfPossession(

--- a/src/interfaces/IConsensusRegistry.sol
+++ b/src/interfaces/IConsensusRegistry.sol
@@ -30,6 +30,7 @@ interface IConsensusRegistry {
         address[] committee;
         uint256 epochIssuance;
         uint64 blockHeight;
+        uint32 epochId;
         uint32 epochDuration;
         uint8 stakeVersion;
     }

--- a/test/consensus/ConsensusRegistryTestFuzz.t.sol
+++ b/test/consensus/ConsensusRegistryTestFuzz.t.sol
@@ -142,10 +142,12 @@ contract ConsensusRegistryTestFuzz is ConsensusRegistryTestUtils {
         uint32 newEpoch = consensusRegistry.getCurrentEpoch() + 1;
         address[] memory newCommittee = consensusRegistry.getEpochInfo(newEpoch).committee;
         vm.expectEmit(true, true, true, true);
-        emit IConsensusRegistry.NewEpoch(IConsensusRegistry.EpochInfo(
+        emit IConsensusRegistry
+            .NewEpoch(IConsensusRegistry.EpochInfo(
                 newCommittee,
                 epochInfo.epochIssuance,
                 uint64(block.number + 1),
+                newEpoch,
                 epochInfo.epochDuration,
                 epochInfo.stakeVersion
             ));


### PR DESCRIPTION
This PR fixes finding 1161 (telcoin-network closes [#416](https://github.com/Telcoin-Association/telcoin-network/issues/416)) by hardening epoch info ring buffers with a new `EpochInfo::epochId` struct member with checks to prevent read-only misalignments due to wraparounds.

It also implements early population during construction to set IDs which are known ahead of time (similarly to initial validator committees).