### PR TITLE
Fix native faucet drip reverting on the TEL precompile's EXTCODESIZE guard

### DIFF
--- a/src/testnet/StablecoinManager.sol
+++ b/src/testnet/StablecoinManager.sol
@@ -26,7 +26,7 @@ contract StablecoinManager is StablecoinHandler, TNFaucet, UUPSUpgradeable {
         uint256 decimals;
     }
 
-    error LowLevelCallFailure();
+    error LowLevelCallFailure(bytes returnData);
     error InvalidOrDisabled(address token);
     error AlreadyEnabled(address token);
     error InvalidDripAmount(uint256 dripAmount);
@@ -176,7 +176,12 @@ contract StablecoinManager is StablecoinHandler, TNFaucet, UUPSUpgradeable {
         uint256 amount;
         if (token == NATIVE_TOKEN_POINTER) {
             amount = getNativeDripAmount();
-            TEL_MINT.mint(recipient, amount);
+            // Low-level call bypasses Solidity's typed-interface EXTCODESIZE guard, which
+            // would otherwise revert because the TEL precompile at 0x07e1 has no bytecode
+            // in state (revm dispatches it at runtime). Mirrors the BlsG1.sol pattern.
+            (bool ok, bytes memory ret) =
+                address(TEL_MINT).call(abi.encodeWithSelector(ITELMint.mint.selector, recipient, amount));
+            if (!ok) revert LowLevelCallFailure(ret);
         } else {
             amount = getDripAmount();
             IStablecoin(token).mintTo(recipient, amount);
@@ -234,8 +239,8 @@ contract StablecoinManager is StablecoinHandler, TNFaucet, UUPSUpgradeable {
     function rescueCrypto(IERC20 token, uint256 amount) public onlyRole(MAINTAINER_ROLE) {
         if (address(token) == address(0x0)) {
             // Native Token
-            (bool r,) = _msgSender().call{ value: amount }("");
-            if (!r) revert LowLevelCallFailure();
+            (bool r, bytes memory ret) = _msgSender().call{ value: amount }("");
+            if (!r) revert LowLevelCallFailure(ret);
         } else {
             // ERC20s
             token.safeTransfer(_msgSender(), amount);

--- a/test/faucet/StablecoinManager.t.sol
+++ b/test/faucet/StablecoinManager.t.sol
@@ -6,6 +6,7 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
 import { StablecoinHandler } from "../../src/testnet/StablecoinHandler.sol";
 import { Stablecoin } from "../../src/testnet/Stablecoin.sol";
 import { ITELMint } from "../../src/interfaces/ITELMint.sol";
+import { TNFaucet } from "../../src/testnet/TNFaucet.sol";
 import "../../src/testnet/StablecoinManager.sol";
 
 contract StablecoinManagerTest is Test {
@@ -288,6 +289,31 @@ contract StablecoinManagerTest is Test {
 
         vm.prank(funder);
         stablecoinManager.dripTo(address(0), recipient);
+
+        uint256 lastFulfilledDrip = stablecoinManager.getLastFulfilledDripTimestamp(address(0), recipient);
+        assertEq(lastFulfilledDrip, block.timestamp);
+    }
+
+    /// @dev Regression guard: on the real chain, `0x07e1` has no bytecode (the precompile is
+    /// dispatched by revm before bytecode is consulted), so a Solidity typed-interface call
+    /// reverts on its auto-emitted EXTCODESIZE guard. The `.call()` path must not revert.
+    /// This test intentionally DOES NOT `vm.mockCall` (which would etch dummy code) nor
+    /// `vm.etch` at 0x07e1 — leaving the codesize == 0 and proving the low-level path works.
+    function testNativeCurrencyDrip_LowLevelCall_NoEtch() public {
+        address recipient = address(0xbeefbabe);
+
+        // sanity: 0x07e1 has no code, matching real-chain state
+        assertEq(address(0x7e1).code.length, 0);
+
+        uint256 nativeDripAmt = stablecoinManager.getNativeDripAmount();
+
+        vm.warp(block.timestamp + 1 days);
+
+        vm.expectEmit(true, true, true, true);
+        emit TNFaucet.Drip(address(0), recipient, nativeDripAmt);
+
+        vm.prank(recipient);
+        stablecoinManager.drip(address(0));
 
         uint256 lastFulfilledDrip = stablecoinManager.getLastFulfilledDripTimestamp(address(0), recipient);
         assertEq(lastFulfilledDrip, block.timestamp);


### PR DESCRIPTION
- Replace the typed `TEL_MINT.mint(...)` call in `StablecoinManager.drip` with a low-level `.call` so the compiler-emitted EXTCODESIZE check no longer reverts on `0x07e1`, which has no bytecode on the live chain (revm dispatches the precompile at runtime). Same pattern already used in `BlsG1.sol`.
- Widen `LowLevelCallFailure` to carry the returned bytes, and propagate the return data from the native branch of `rescueCrypto` for parity.
- Add a regression test that exercises the native drip with `code.length == 0` at `0x07e1` — no `vm.etch`, no `vm.mockCall` — so the failure mode can't creep back in under unit tests that would otherwise mask it.

closes #94 