### PR TITLE
add 0xfe to precompile in genesis

### DIFF
--- a/deployments/genesis/precompile-config.yaml
+++ b/deployments/genesis/precompile-config.yaml
@@ -56,4 +56,4 @@
 "0x00000000000000000000000000000000000007e1": # TEL precompile
   nonce: 0
   balance: 0
-  code: 0xfe
+  code: "0xfe"

--- a/deployments/genesis/precompile-config.yaml
+++ b/deployments/genesis/precompile-config.yaml
@@ -53,3 +53,7 @@
 "0x3fAB184622Dc19b6109349B94811493BF2a45362": # use nonce 0 for creating 0x4e59b44847b379578588920cA78FbF26c0B4956C
   nonce: 1
   balance: 0
+"0x00000000000000000000000000000000000007e1": # TEL precompile
+  nonce: 0
+  balance: 0
+  code: 0xfe

--- a/script/GenerateGenesisPrecompileConfig.s.sol
+++ b/script/GenerateGenesisPrecompileConfig.s.sol
@@ -90,6 +90,9 @@ contract GenerateGenesisPrecompileConfig is GenesisPrecompiler, Script {
         // Arachnid deterministic deployment proxy (CREATE2)
         instantiateArachnidFactory();
 
+        // TEL precompile (native Rust handler at 0x7e1, needs code for EXTCODESIZE check)
+        instantiateTelPrecompile();
+
         vm.stopBroadcast();
     }
 
@@ -185,6 +188,14 @@ contract GenerateGenesisPrecompileConfig is GenesisPrecompiler, Script {
         );
         vm.writeLine(dest, "  nonce: 1");
         vm.writeLine(dest, "  balance: 0");
+    }
+
+    /// @dev Writes TEL precompile genesis account so EXTCODESIZE returns non-zero
+    function instantiateTelPrecompile() internal {
+        vm.writeLine(dest, '"0x00000000000000000000000000000000000007e1": # TEL precompile');
+        vm.writeLine(dest, "  nonce: 0");
+        vm.writeLine(dest, "  balance: 0");
+        vm.writeLine(dest, "  code: 0xfe");
     }
 
     /// @dev Writes EIP-2935 and EIP-4788 system contracts configuration directly to the yaml


### PR DESCRIPTION
The TEL precompile at 0x7e1 is a native Rust precompile (not EVM bytecode). When Solidity contracts make high-level calls to it (e.g., ITELMint(0x7e1).transfer(...)), the compiler inserts an EXTCODESIZE check that reverts if the target has no code. Without a genesis account entry, this check fails.

The fix: add a genesis account at 0x7e1 with code: 0xfe (the INVALID opcode, 1 byte). This makes EXTCODESIZE return 1, satisfying the check, while the actual call is intercepted by the native precompile handler before the EVM ever tries to execute the bytecode.

closes #102 