### PR TITLE
fix(ci): materialize ring buffer tail on GitAttestationRegistry grow

### DIFF
--- a/src/CI/GitAttestationRegistry.sol
+++ b/src/CI/GitAttestationRegistry.sol
@@ -69,9 +69,18 @@ contract GitAttestationRegistry is AccessControl {
         for (uint8 i; i < itemsToCopy; ++i) {
             ringBuffer.push(newBuffer[i]);
         }
+        // materialize the remaining slots so storage length always equals `bufferSize`; on grow
+        // `itemsToCopy` is the smaller size, so [itemsToCopy, newSize) must exist before `head` reaches them
+        for (uint8 i = itemsToCopy; i < newSize; ++i) {
+            ringBuffer.push(GitCommitHashRecord(bytes20(0x0), false));
+        }
 
         bufferSize = newSize;
         head = itemsToCopy % newSize;
+
+        // `attestGitCommitHash` writes `ringBuffer[head]`; `gitCommitHashAttested` reads [0, bufferSize)
+        assert(ringBuffer.length == bufferSize);
+        assert(head < bufferSize);
 
         emit BufferSizeChanged(newSize);
     }

--- a/test/CI/GitAttestationRegistry.t.sol
+++ b/test/CI/GitAttestationRegistry.t.sol
@@ -113,4 +113,60 @@ contract GitAttestationRegistryTest is Test {
         result = fuzzGitAttestationRegistry.gitCommitHashAttested(gitHash);
         assertTrue(result);
     }
+
+    /// @dev Fills the 4-slot buffer so `head` wraps to 0. Hashes start at 1 because the zero value
+    /// means "empty".
+    function _fillBuffer() internal {
+        vm.startPrank(maintainer);
+        for (uint8 i; i < 4; ++i) {
+            gitAttestationRegistry.attestGitCommitHash(bytes20(uint160(i + 1)), true);
+        }
+        vm.stopPrank();
+    }
+
+    /// @notice Growing materializes the new tail slots, so the next attestation writes in bounds.
+    function test_growThenAttest_doesNotPanic() public {
+        _fillBuffer();
+
+        vm.prank(admin);
+        gitAttestationRegistry.setBufferSize(6);
+
+        bytes20 fresh = bytes20(uint160(0xbeef));
+        vm.prank(maintainer);
+        gitAttestationRegistry.attestGitCommitHash(fresh, true);
+
+        assertTrue(gitAttestationRegistry.gitCommitHashAttested(fresh));
+    }
+
+    /// @notice After a grow, a lookup that misses returns false; every slot in [0, bufferSize) exists.
+    function test_growThenMissingLookup_returnsFalse() public {
+        _fillBuffer();
+
+        vm.prank(admin);
+        gitAttestationRegistry.setBufferSize(6);
+
+        assertFalse(gitAttestationRegistry.gitCommitHashAttested(bytes20(uint160(0xdead))));
+    }
+
+    /// @notice `ringBuffer.length` tracks `bufferSize` across a grow, so the top slot is addressable.
+    function test_growMaterializesEverySlot() public {
+        vm.prank(admin);
+        gitAttestationRegistry.setBufferSize(6);
+
+        assertEq(gitAttestationRegistry.bufferSize(), 6);
+        (bytes20 hash_,) = gitAttestationRegistry.ringBuffer(5);
+        assertEq(hash_, bytes20(0x0));
+    }
+
+    /// @notice A second grow does not revert; `head < ringBuffer.length` holds after the first.
+    function test_consecutiveGrows() public {
+        _fillBuffer();
+
+        vm.startPrank(admin);
+        gitAttestationRegistry.setBufferSize(6);
+        gitAttestationRegistry.setBufferSize(8);
+        vm.stopPrank();
+
+        assertEq(gitAttestationRegistry.bufferSize(), 8);
+    }
 }


### PR DESCRIPTION
## Finding

Cantina review (Cryptara). `setBufferSize` corrupts the ring buffer when growing.

On a grow (`newSize > bufferSize`), `itemsToCopy = min(old, new) = old`. The rebuild deletes `ringBuffer` and pushes only `itemsToCopy` records, while setting `bufferSize = newSize` and `head = old % newSize = old`. That leaves `head == ringBuffer.length`:

- the next `attestGitCommitHash` writes `ringBuffer[head]` out of bounds -> `Panic(0x32)`
- `gitCommitHashAttested` reverts for any hash not in the first `old` slots
- a further grow or same-size call reverts

The only recovery is a counter-intuitive shrink to a size <= the old length. This is reachable by an ordinary admin capacity increase, so the tooling can brick itself. CI tooling only, no funds at risk.

## Fix

- Pad the buffer to `newSize` with empty records after the copy, so storage length always equals `bufferSize`.
- Assert `ringBuffer.length == bufferSize` and `head < bufferSize`.

## Tests

Four regression tests that fail against the prior implementation and pass here: attest after grow, missing lookup after grow, full-slot materialization, and consecutive grows. The pre-existing `testResizeBuffer` missed the bug because it never attests after growing.

Full suite: `test/CI` 9 passed.

Closes #154.
