### PR TITLE
fix(consensus): reindex BLS reverse lookup in migrateValidatorSets

### DIFF
--- a/src/consensus/ConsensusRegistry.sol
+++ b/src/consensus/ConsensusRegistry.sol
@@ -150,8 +150,8 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         }
     }
 
-    /// @notice One-time back-fill of the per-status validator sets and the cached eligible count for
-    /// an in-place upgrade from a deployment that predates the sets.
+    /// @notice One-time back-fill of the per-status validator sets, the cached eligible count, and the
+    /// BLS pubkey reverse index for an in-place upgrade from a deployment that predates them.
     /// @dev The storage layout is a clean append (the sets were appended after the pre-existing
     /// variables), so `validators[*]` and the ConsensusNFTs survive the code swap untouched; only
     /// `validatorSets` / `eligibleValidatorCount` start empty and must be rebuilt before the new read
@@ -166,6 +166,15 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         uint256 eligible;
         for (uint256 i; i < supply; ++i) {
             address validatorAddress = ownerOf(tokenByIndex(i));
+
+            // key the BLS reverse index by `_blsKeyId` so `isValidator` and `_spendBLSPubkey` resolve
+            // this validator and enforce dedup; clear the pubkey-hash-keyed slot
+            bytes memory blsPubkey = blsPubkeys[validatorAddress];
+            if (blsPubkey.length == 96) {
+                delete blsPubkeyHashToValidator[keccak256(blsPubkey)];
+                blsPubkeyHashToValidator[_blsKeyId(blsPubkey)] = validatorAddress;
+            }
+
             ValidatorInfo storage validator = validators[validatorAddress];
             if (validator.isRetired) continue;
 

--- a/test/consensus/ConsensusRegistryMigrationTest.t.sol
+++ b/test/consensus/ConsensusRegistryMigrationTest.t.sol
@@ -88,6 +88,28 @@ contract ConsensusRegistryMigrationTest is ConsensusRegistryTestUtils {
         assertEq(consensusRegistry.getValidators(ValidatorStatus.Active).length, 4);
     }
 
+    function test_migrateValidatorSets_reindexesBlsReverseLookup() public {
+        // emulate a deployment whose BLS reverse index is keyed by keccak256(blsPubkey) rather than the
+        // canonical `_blsKeyId` (x-coordinate) used by every current read path
+        for (uint256 i; i < initialValidators.length; ++i) {
+            bytes memory pubkey = initialBlsPubkeys[i];
+            address v = initialValidators[i].validatorAddress;
+
+            _storeBlsReverseIndex(_blsKeyIdLocal(pubkey), address(0));
+            _storeBlsReverseIndex(keccak256(pubkey), v);
+
+            assertFalse(consensusRegistry.isValidator(pubkey), "reverse index should miss pre-migration");
+        }
+
+        vm.prank(sysAddress);
+        consensusRegistry.migrateValidatorSets();
+
+        // every validator now resolves through the `_blsKeyId`-keyed slot, and the stale slot is cleared
+        for (uint256 i; i < initialValidators.length; ++i) {
+            assertTrue(consensusRegistry.isValidator(initialBlsPubkeys[i]), "reverse index reindexed");
+        }
+    }
+
     function test_migrateValidatorSets_revertsForNonSystemCaller() public {
         vm.expectRevert(abi.encodeWithSelector(SystemCallable.OnlySystemCall.selector, address(this)));
         consensusRegistry.migrateValidatorSets();
@@ -128,5 +150,20 @@ contract ConsensusRegistryMigrationTest is ConsensusRegistryTestUtils {
             }
         }
         vm.store(address(consensusRegistry), bytes32(uint256(43)), bytes32(0)); // eligibleValidatorCount = 0
+    }
+
+    /// @dev Writes `blsPubkeyHashToValidator[key] = v` directly. The mapping lives at storage slot 16
+    /// (see `forge inspect ConsensusRegistry storage-layout`).
+    function _storeBlsReverseIndex(bytes32 key, address v) internal {
+        bytes32 slot = keccak256(abi.encode(key, uint256(16)));
+        vm.store(address(consensusRegistry), slot, bytes32(uint256(uint160(v))));
+    }
+
+    /// @dev Mirrors `ConsensusRegistry._blsKeyId`: keccak of the 96-byte compressed key with the three
+    /// flag bits in the most-significant byte cleared.
+    function _blsKeyIdLocal(bytes memory compressed) internal pure returns (bytes32) {
+        bytes memory b = bytes.concat(compressed);
+        b[0] = b[0] & bytes1(0x1f);
+        return keccak256(b);
     }
 }


### PR DESCRIPTION
## Finding

Cantina review (phaze). `migrateValidatorSets` back-fills the per-status `EnumerableSet`s and `eligibleValidatorCount`, but not `blsPubkeyHashToValidator`.

Deployments predating `_blsKeyId` keyed that mapping on `keccak256(blsPubkey)`. Every current read path keys on `_blsKeyId` (the x-coordinate with the three flag bits cleared), and the compression bit is always set, so the two ids never coincide. After an in-place upgrade:

- `isValidator(blsPubkey)` returns false for existing validators
- `_spendBLSPubkey`'s duplicate-key check reads an empty slot, so an already-registered BLS key can be registered again

The forward index `blsPubkeys[address]` is untouched, so `getBlsPubkey(address)` keeps working - which is why the gap was not obvious.

## Fix

Inside the existing NFT-enumeration loop, re-key each validator's reverse-index entry to `_blsKeyId` and clear the stale `keccak256`-keyed slot. Idempotent on a freshly seeded genesis (the stale slot is already empty and the `_blsKeyId` slot already holds the address).

## Known limitation

Retired validators whose ConsensusNFT is burned are not reachable by `tokenByIndex` enumeration, so their spent keys are not re-pointed. This relaxes dedup for retired keys only. Flagging for the researchers to confirm acceptability.

## Tests

Adds `test_migrateValidatorSets_reindexesBlsReverseLookup`, which emulates the legacy `keccak256` keying via `vm.store` and asserts `isValidator` resolves every validator after migration. It fails against the prior implementation. Existing migration tests unchanged and passing.

Closes #148.
