### PR TITLE
fix(consensus): preserve region on stake; guard genesis epoch duration

### DIFF
--- a/src/consensus/ConsensusRegistry.sol
+++ b/src/consensus/ConsensusRegistry.sol
@@ -777,8 +777,9 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
     {
         // record the validator as `Undefined`, then transition to `Staked` through `_setStatus` so the
         // `Staked` set add happens in the one place that maintains membership (the address is already set)
+        uint8 region = validators[validatorAddress].region;
         validators[validatorAddress] = ValidatorInfo(
-            validatorAddress, PENDING_EPOCH, uint32(0), ValidatorStatus.Undefined, false, stakeVersion, uint8(0)
+            validatorAddress, PENDING_EPOCH, uint32(0), ValidatorStatus.Undefined, false, stakeVersion, region
         );
         ValidatorInfo storage newValidator = validators[validatorAddress];
         _setStatus(newValidator, ValidatorStatus.Staked);
@@ -1158,6 +1159,7 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         }
 
         // set stake storage configs
+        if (genesisConfig_.epochDuration == 0) revert InvalidDuration(genesisConfig_.epochDuration);
         versions[0] = genesisConfig_;
 
         // set nextCommitteeSize based on current committee

--- a/test/consensus/ConsensusRegistryTest.t.sol
+++ b/test/consensus/ConsensusRegistryTest.t.sol
@@ -9,6 +9,7 @@ import { SystemCallable } from "src/consensus/SystemCallable.sol";
 import { StakeManager } from "src/consensus/StakeManager.sol";
 import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
 import { RewardInfo, Slash, IStakeManager } from "src/interfaces/IStakeManager.sol";
+import { IConsensusRegistry } from "src/interfaces/IConsensusRegistry.sol";
 import { ConsensusRegistryTestUtils } from "./ConsensusRegistryTestUtils.sol";
 
 contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
@@ -136,6 +137,30 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         vm.prank(crOwner);
         consensusRegistry.setValidatorRegion(validator5, 3);
         assertEq(consensusRegistry.getValidator(validator5).region, 3);
+    }
+
+    function test_stake_preservesRegionSetBeforeStake() public {
+        vm.prank(crOwner);
+        consensusRegistry.mint(validator5);
+
+        // region assigned while the validator is minted but not yet staked
+        vm.prank(crOwner);
+        consensusRegistry.setValidatorRegion(validator5, 7);
+        assertEq(consensusRegistry.getValidator(validator5).region, 7);
+
+        vm.prank(validator5);
+        consensusRegistry.stake{ value: stakeAmount_ }(
+            validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig)
+        );
+
+        assertEq(uint8(consensusRegistry.getValidator(validator5).currentStatus), uint8(ValidatorStatus.Staked));
+        assertEq(consensusRegistry.getValidator(validator5).region, 7);
+    }
+
+    function test_constructor_revertsOnZeroEpochDuration() public {
+        StakeConfig memory badConfig = StakeConfig(stakeAmount_, minWithdrawAmount_, epochIssuance_, 0);
+        vm.expectRevert(abi.encodeWithSelector(IConsensusRegistry.InvalidDuration.selector, uint32(0)));
+        new ConsensusRegistry(badConfig, initialValidators, initialBlsPubkeys, initialBLSPops, crOwner);
     }
 
     function test_setValidatorRegion_pendingActivationValidator() public {


### PR DESCRIPTION
## Findings

Two low-severity Cantina items (phaze), bundled into one PR.

### Region overwrite on stake (`_recordStaked`)

A validator's region can be assigned by governance before it stakes. `_recordStaked` wrote a fresh `ValidatorInfo` with the region hardcoded to `uint8(0)`, silently clobbering it. Fix reads the existing region and carries it into the new struct.

### Missing genesis epoch-duration guard (constructor)

`upgradeStakeVersion` rejects `epochDuration == 0` for every version, but the constructor assigned `versions[0]` directly and skipped that check, so genesis could seed a zero-duration config. Fix applies the same guard to the genesis config.

## Tests

- `test_stake_preservesRegionSetBeforeStake`: a region set on a minted-but-unstaked validator survives staking.
- `test_constructor_revertsOnZeroEpochDuration`: the constructor reverts `InvalidDuration` on a zero epoch duration.

Both fail against the prior code. Full `ConsensusRegistryTest` suite passes.

Closes #149.
Closes #150.
