### PR TITLE
fix(consensus): slash settlement, stake top-ups, issuance withdrawal, emergency exit

### DIFF
--- a/src/consensus/ConsensusRegistry.sol
+++ b/src/consensus/ConsensusRegistry.sol
@@ -51,6 +51,10 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
     /// than three set-length reads. Invariant-tested against the eligible set sizes.
     uint256 internal eligibleValidatorCount;
 
+    /// @notice When true, `topUpSlashedStake` is restricted to governance; when false, validators
+    /// and their delegators may also restore their own slashed stake
+    bool public topUpAuthorityRequired;
+
     /// @dev Signals a validator's pending status until activation/exit to correctly apply incentives
     uint32 internal constant PENDING_EPOCH = type(uint32).max;
 
@@ -101,8 +105,12 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
             if (isRetired(reward.validatorAddress)) continue;
 
             uint8 rewardeeVersion = validators[reward.validatorAddress].stakeVersion;
-            // derive validator's weight using initial stake for stability
-            uint256 stakeAmount = versions[rewardeeVersion].stakeAmount;
+            // derive validator's weight from its effective stake: the version's full stake amount,
+            // capped to the outstanding balance when slashes have reduced it below that amount
+            // (restorable via `topUpSlashedStake`). Rewards above the stake amount never add weight
+            uint256 versionStakeAmount = versions[rewardeeVersion].stakeAmount;
+            uint256 balance = balances[reward.validatorAddress];
+            uint256 stakeAmount = balance < versionStakeAmount ? balance : versionStakeAmount;
             uint256 weight = stakeAmount * reward.consensusHeaderCount;
 
             totalWeight += weight;
@@ -140,6 +148,8 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
             if (isRetired(slash.validatorAddress)) continue;
 
             if (balances[slash.validatorAddress] > slash.amount) {
+                // ledger-only decrement: the confiscated native TEL remains held by this contract
+                // and is consolidated on Issuance at settlement (top-up, unstake, or burn)
                 balances[slash.validatorAddress] -= slash.amount;
             } else {
                 // eject validators whose balance would reach 0
@@ -464,6 +474,51 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
     }
 
     /// @inheritdoc IConsensusRegistry
+    function topUpSlashedStake(address validatorAddress) external payable override whenNotPaused {
+        // require `validatorAddress` is known & whitelisted, having been issued a ConsensusNFT by governance
+        _checkConsensusNFTOwner(validatorAddress);
+
+        // governance may always top up; other callers must be the validator or its delegator,
+        // and only while self-service top-ups are enabled
+        if (msg.sender != owner()) {
+            if (topUpAuthorityRequired) revert TopUpAuthorityRequired();
+            address recipient = _getRecipient(validatorAddress);
+            if (msg.sender != validatorAddress && msg.sender != recipient) revert NotRecipient(recipient);
+        }
+
+        // require validator status is `Staked`, `PendingActivation`, or `Active`
+        ValidatorStatus status = validators[validatorAddress].currentStatus;
+        if (
+            status != ValidatorStatus.Staked && status != ValidatorStatus.PendingActivation
+                && status != ValidatorStatus.Active
+        ) {
+            revert InvalidStatus(status);
+        }
+
+        uint8 validatorVersion = validators[validatorAddress].stakeVersion;
+        uint256 stakeAmount = versions[validatorVersion].stakeAmount;
+        uint256 currentBalance = balances[validatorAddress];
+        if (currentBalance >= stakeAmount) {
+            revert StakeNotSlashed(validatorAddress, currentBalance, validatorVersion);
+        }
+
+        uint256 deficit = stakeAmount - currentBalance;
+        if (msg.value != deficit) {
+            revert InvalidDeficitAmount(validatorAddress, msg.value, validatorVersion);
+        }
+
+        balances[validatorAddress] += deficit;
+        // this contract already holds the full stake-backed native TEL for a slashed validator
+        // (slashes decrement only the balance ledger), so the top-up value is consolidated on
+        // Issuance where it is repurposed for future reward distribution
+        (bool r,) = issuance.call{ value: msg.value }("");
+        // this is believed to be impossible
+        if (!r) revert IssuanceTransferFailed();
+
+        emit ValidatorStakeToppedUp(validatorAddress, deficit);
+    }
+
+    /// @inheritdoc IConsensusRegistry
     function activate() external override whenNotPaused {
         // require caller is whitelisted, having been issued a ConsensusNFT by governance
         _checkConsensusNFTOwner(msg.sender);
@@ -552,7 +607,7 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
             if (refundAmount > 0) {
                 balances[validatorAddress] -= refundAmount;
                 // Route through Issuance (same pattern as _unstake)
-                Issuance(issuance).distributeStakeReward{ value: refundAmount }(recipient, 0);
+                Issuance(issuance).distributeStakeReward{ value: refundAmount }(recipient, 0, false);
             }
 
             // consolidate confiscated slash remainder on Issuance (same as _unstake pattern)
@@ -599,7 +654,7 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
     }
 
     /// @inheritdoc StakeManager
-    function unstake(address validatorAddress) external override whenNotPaused nonReentrant {
+    function unstake(address validatorAddress, bool emergencyExit) external override whenNotPaused nonReentrant {
         // require validator holds a ConsensusNFT and the caller is the validator or its delegator
         address recipient = _checkStakeOriginator(validatorAddress);
 
@@ -611,7 +666,7 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         _retire(validator);
 
         // return stake and send any outstanding rewards
-        uint256 stakeAndRewards = _unstake(validatorAddress, recipient);
+        uint256 stakeAndRewards = _unstake(validatorAddress, recipient, emergencyExit);
 
         emit RewardsClaimed(recipient, stakeAndRewards);
     }
@@ -654,6 +709,17 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         (bool r,) = issuance.call{ value: msg.value }("");
         // this is believed to be impossible
         if (!r) revert IssuanceTransferFailed();
+    }
+
+    /// @inheritdoc StakeManager
+    function issuanceWithdrawal(uint256 amount) external override onlyOwner {
+        Issuance(issuance).withdraw(amount, msg.sender);
+    }
+
+    /// @inheritdoc IConsensusRegistry
+    function setTopUpAuthorityRequired(bool required) external override onlyOwner {
+        topUpAuthorityRequired = required;
+        emit TopUpAuthorityRequirementUpdated(required);
     }
 
     /**
@@ -951,13 +1017,13 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         _ejectFromCommittees(validatorAddress, numEligible);
 
         // settle ledgers
-        (uint256 outstandingBalance, uint256 initialStakeAmt,) = getBalanceBreakdown(validatorAddress);
+        (, uint256 initialStakeAmt,) = getBalanceBreakdown(validatorAddress);
         // rewards are already held on Issuance contract, so wiping registry's balance ledger effectively confiscates
         // them
         balances[validatorAddress] = 0;
-        // confiscate outstanding stake balance by consolidating it on the Issuance contract
-        uint256 confiscatedStake = outstandingBalance < initialStakeAmt ? outstandingBalance : initialStakeAmt;
-        (bool r,) = issuance.call{ value: confiscatedStake }("");
+        // confiscate the validator's entire stake-backed native TEL, including any previously
+        // slashed remainder still held by this contract, by consolidating it on Issuance
+        (bool r,) = issuance.call{ value: initialStakeAmt }("");
         // this is believed to be impossible
         if (!r) revert IssuanceTransferFailed();
 
@@ -965,7 +1031,7 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         _exit(validator, currentEpoch);
         _retire(validator);
         address recipient = _getRecipient(validatorAddress);
-        _unstake(validatorAddress, recipient);
+        _unstake(validatorAddress, recipient, true);
     }
 
     /// @dev Stores the number of blocks finalized in previous epoch and the voter committee for the new epoch

--- a/src/consensus/Issuance.sol
+++ b/src/consensus/Issuance.sol
@@ -24,9 +24,20 @@ contract Issuance {
 
     /// @notice May only be called by StakeManager as part of claim, unstake or burn flow
     /// @dev Sends `rewardAmount` and forwards `msg.value` if stake amount is additionally provided
-    function distributeStakeReward(address recipient, uint256 rewardAmount) external payable virtual onlyStakeManager {
+    /// @param emergencyExit When true, forfeits `rewardAmount` and forwards only `msg.value`, so a
+    /// stake withdrawal can proceed even when this contract's balance cannot cover accrued rewards
+    function distributeStakeReward(
+        address recipient,
+        uint256 rewardAmount,
+        bool emergencyExit
+    )
+        external
+        payable
+        virtual
+        onlyStakeManager
+    {
         uint256 bal = address(this).balance;
-        uint256 totalAmount = rewardAmount + msg.value;
+        uint256 totalAmount = emergencyExit ? msg.value : rewardAmount + msg.value;
         if (bal < totalAmount) {
             revert InsufficientBalance(bal, totalAmount);
         }
@@ -35,8 +46,19 @@ contract Issuance {
         if (!res) revert RewardDistributionFailure(recipient);
     }
 
-    /// @notice Received TEL cannot be recovered; it is effectively burned cryptographically
-    /// The only way received TEL can be re-minted is as staking issuance rewards
-    /// @notice Only governance may burn TEL in this manner
+    /// @notice Sends `amount` of this contract's TEL balance to `recipient`
+    /// @dev May only be called by StakeManager, which restricts the call to its governance owner
+    function withdraw(uint256 amount, address recipient) external onlyStakeManager {
+        uint256 bal = address(this).balance;
+        if (bal < amount) {
+            revert InsufficientBalance(bal, amount);
+        }
+
+        (bool res,) = recipient.call{ value: amount }("");
+        if (!res) revert RewardDistributionFailure(recipient);
+    }
+
+    /// @notice Received TEL leaves this contract only as staking issuance rewards or
+    /// through a governance withdrawal via the StakeManager
     receive() external payable onlyStakeManager { }
 }

--- a/src/consensus/StakeManager.sol
+++ b/src/consensus/StakeManager.sol
@@ -39,13 +39,7 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
     constructor(string memory name, string memory symbol) ERC721(name, symbol) { }
 
     /// @inheritdoc IStakeManager
-    function stake(
-        bytes calldata blsPubkey,
-        ProofOfPossession calldata proofOfPossession
-    )
-        external
-        payable
-        virtual;
+    function stake(bytes calldata blsPubkey, ProofOfPossession calldata proofOfPossession) external payable virtual;
 
     /// @inheritdoc IStakeManager
     function delegateStake(
@@ -62,7 +56,7 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
     function claimStakeRewards(address ecsdaPubkey) external virtual;
 
     /// @inheritdoc IStakeManager
-    function unstake(address validatorAddress) external virtual;
+    function unstake(address validatorAddress, bool emergencyExit) external virtual;
 
     /// @inheritdoc IStakeManager
     function getRewards(address validatorAddress) public view virtual returns (uint256);
@@ -88,6 +82,9 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
 
     /// @inheritdoc IStakeManager
     function allocateIssuance() external payable virtual override;
+
+    /// @inheritdoc IStakeManager
+    function issuanceWithdrawal(uint256 amount) external virtual override;
 
     /**
      *
@@ -189,12 +186,20 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
         // check rewards are claimable and send via the Issuance contract
         uint256 rewards = _checkRewards(validatorAddress, validatorVersion);
         balances[validatorAddress] -= rewards;
-        Issuance(issuance).distributeStakeReward(recipient, rewards);
+        Issuance(issuance).distributeStakeReward(recipient, rewards, false);
 
         return rewards;
     }
 
-    function _unstake(address validatorAddress, address recipient) internal virtual returns (uint256) {
+    function _unstake(
+        address validatorAddress,
+        address recipient,
+        bool emergencyExit
+    )
+        internal
+        virtual
+        returns (uint256)
+    {
         _burn(_getTokenId(validatorAddress));
         if (totalSupply() == 0) revert InvalidSupply();
 
@@ -219,10 +224,11 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
             if (!r) revert IssuanceTransferFailed();
         }
 
-        // debit `unstakeAmt` due to recipient from this contract balance, debit rewards from Issuance balance
-        Issuance(issuance).distributeStakeReward{ value: unstakeAmt }(recipient, rewards);
+        // debit `unstakeAmt` due to recipient from this contract balance, debit rewards from Issuance
+        // balance unless the recipient opted to forfeit rewards via emergency exit
+        Issuance(issuance).distributeStakeReward{ value: unstakeAmt }(recipient, rewards, emergencyExit);
 
-        return unstakeAmt + rewards;
+        return emergencyExit ? unstakeAmt : unstakeAmt + rewards;
     }
 
     function _checkRewards(address validatorAddress, uint8 validatorVersion) internal virtual returns (uint256) {

--- a/src/interfaces/IConsensusRegistry.sol
+++ b/src/interfaces/IConsensusRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 pragma solidity 0.8.35;
 
-import {RewardInfo, Slash} from "./IStakeManager.sol";
+import { RewardInfo, Slash } from "./IStakeManager.sol";
 
 /**
  * @title ConsensusRegistry Interface
@@ -83,6 +83,20 @@ interface IConsensusRegistry {
     /// @param validator The full ValidatorInfo of the ineligible validator
     error IneligibleUnstake(ValidatorInfo validator);
 
+    /// @notice Thrown on top-up attempts for a validator whose balance is not below its stake amount
+    /// @param validatorAddress The validator that is not slashed
+    /// @param balance The validator's current outstanding balance
+    /// @param stakeVersion The validator's stake version defining the required stake amount
+    error StakeNotSlashed(address validatorAddress, uint256 balance, uint8 stakeVersion);
+    /// @notice Thrown when a top-up is attempted by a non-governance caller while top-ups
+    /// are restricted to the governance top-up authority
+    error TopUpAuthorityRequired();
+    /// @notice Thrown when a top-up's `msg.value` does not exactly match the validator's stake deficit
+    /// @param validatorAddress The validator being topped up
+    /// @param value The `msg.value` that was provided
+    /// @param stakeVersion The validator's stake version defining the required stake amount
+    error InvalidDeficitAmount(address validatorAddress, uint256 value, uint8 stakeVersion);
+
     /// @notice Emitted when a validator first stakes, entering the Staked lifecycle state
     /// @param validator The newly staked validator's info
     event ValidatorStaked(ValidatorInfo validator);
@@ -141,6 +155,15 @@ interface IConsensusRegistry {
     /// in-place upgrade from a deployment that predates them
     /// @param eligibleValidatorCount The committee-eligible count after the back-fill
     event ValidatorSetsMigrated(uint256 eligibleValidatorCount);
+
+    /// @notice Emitted when governance toggles whether `topUpSlashedStake` is restricted to
+    /// the governance top-up authority
+    /// @param required The new value of the `topUpAuthorityRequired` flag
+    event TopUpAuthorityRequirementUpdated(bool required);
+    /// @notice Emitted when a slashed validator's balance is restored to its version's full stake amount
+    /// @param validatorAddress The validator whose stake was topped up
+    /// @param amount The deficit that was provided and consolidated on the Issuance contract
+    event ValidatorStakeToppedUp(address indexed validatorAddress, uint256 amount);
 
     /// @dev Validators marked `Active || PendingActivation || PendingExit` are still operational
     /// and thus eligible for committees. Queriable via `getValidators(Active)` status
@@ -251,4 +274,16 @@ interface IConsensusRegistry {
     /// @notice After retiring, a validator's `tokenId == validatorAddress` cannot be reused
     function isRetired(address validatorAddress) external view returns (bool);
 
+    /// @notice Restores a slashed validator's balance to its version's full stake amount
+    /// @dev `msg.value` must equal the exact deficit; it is consolidated on the Issuance contract
+    /// since this contract retains the full stake-backed native TEL when slashes are applied
+    /// @dev Callable by governance at any time; by the validator or its delegator only while
+    /// `topUpAuthorityRequired` is false
+    /// @param validatorAddress The slashed validator to top up; must be `Staked`,
+    /// `PendingActivation`, or `Active`
+    function topUpSlashedStake(address validatorAddress) external payable;
+
+    /// @notice Toggles whether `topUpSlashedStake` is restricted to the governance top-up authority
+    /// @dev Only callable by governance (owner)
+    function setTopUpAuthorityRequired(bool required) external;
 }

--- a/src/interfaces/IStakeManager.sol
+++ b/src/interfaces/IStakeManager.sol
@@ -102,12 +102,7 @@ interface IStakeManager {
     /// @notice Ensuring `uncompressedPubkey` corresponds to `ValidatorInfo::blsPubkey` is better
     /// performed externally in Rust by the protocol due to EIP2537 precompile & EVM limitations
     /// so this contract does not perform any (un)compression checks
-    function stake(
-        bytes calldata blsPubkey,
-        ProofOfPossession calldata proofOfPossession
-    )
-        external
-        payable;
+    function stake(bytes calldata blsPubkey, ProofOfPossession calldata proofOfPossession) external payable;
 
     /// @dev Accepts delegated stake from a non-validator caller authorized by a validator's EIP712 signature
     /// @notice `validatorAddress` must be a validator already in possession of a `ConsensusNFT`
@@ -129,7 +124,9 @@ interface IStakeManager {
     /// @dev Returns previously staked funds in addition to accrued rewards, if any, to the staker
     /// @notice May be used to reverse validator onboarding pre-activation or permanently retire after full exit
     /// @notice Once unstaked and retired, validator addresses cannot be reused
-    function unstake(address validatorAddress) external;
+    /// @param emergencyExit When true, permanently forfeits accrued rewards and returns only the stake
+    /// balance; escape hatch for when the Issuance contract's balance cannot cover the rewards owed
+    function unstake(address validatorAddress, bool emergencyExit) external;
 
     /// @notice Returns the delegation digest that a validator should sign to accept a delegation
     /// @return _ EIP-712 typed struct hash used to enable delegated proof of stake
@@ -166,9 +163,9 @@ interface IStakeManager {
     function upgradeStakeVersion(StakeConfig calldata newVersion) external returns (uint8);
 
     /// @dev Permissioned function to allocate TEL for epoch issuance, ie consensus block rewards
-    /// @notice Allocated TEL cannot be recovered; it is effectively burned cryptographically
-    /// The only way received TEL can be re-minted is as staking issuance rewards
-    /// @notice Only governance may burn TEL in this manner
+    /// @notice Allocated TEL leaves the Issuance contract only as staking issuance rewards or
+    /// through a governance withdrawal via `issuanceWithdrawal`
+    /// @notice Only governance may allocate TEL in this manner
     function allocateIssuance() external payable;
 
     /// @dev Allows a staked validator (or its delegator) to upgrade their stake version in-place.
@@ -183,4 +180,10 @@ interface IStakeManager {
     /// The recipient still receives the correct total ETH via the refund. Validators should claim
     /// rewards before upgrading if they have both accrued rewards and pending slashes.
     function upgradeValidatorStakeVersion(address validatorAddress, uint8 targetVersion) external payable;
+
+    /// @dev Permissioned function to withdraw TEL from the Issuance contract to the caller
+    /// @notice Only governance may withdraw in this manner, eg to recover consolidated slash
+    /// funds or to reduce a prior issuance allocation
+    /// @param amount The amount of TEL to withdraw from the Issuance contract
+    function issuanceWithdrawal(uint256 amount) external;
 }

--- a/test/consensus/ConsensusRegistryTest.t.sol
+++ b/test/consensus/ConsensusRegistryTest.t.sol
@@ -9,6 +9,7 @@ import { SystemCallable } from "src/consensus/SystemCallable.sol";
 import { StakeManager } from "src/consensus/StakeManager.sol";
 import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
 import { RewardInfo, Slash, IStakeManager } from "src/interfaces/IStakeManager.sol";
+import { Issuance } from "src/consensus/Issuance.sol";
 import { ConsensusRegistryTestUtils } from "./ConsensusRegistryTestUtils.sol";
 
 contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
@@ -18,7 +19,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         vm.startStateDiffRecording();
         StakeConfig memory stakeConfig_ = StakeConfig(stakeAmount_, minWithdrawAmount_, epochIssuance_, epochDuration_);
-        ConsensusRegistry tempRegistry = new ConsensusRegistry(stakeConfig_, initialValidators, initialBlsPubkeys, initialBLSPops, crOwner);
+        ConsensusRegistry tempRegistry =
+            new ConsensusRegistry(stakeConfig_, initialValidators, initialBlsPubkeys, initialBLSPops, crOwner);
         Vm.AccountAccess[] memory records = vm.stopAndReturnStateDiff();
         bytes32[] memory slots = saveWrittenSlots(address(tempRegistry), records);
         copyContractState(address(tempRegistry), address(consensusRegistry), slots);
@@ -47,7 +49,9 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
                 active[i].validatorAddress
             );
             assertFalse(consensusRegistry.isRetired(initialValidators[i].validatorAddress));
-            assertTrue(consensusRegistry.isValidator(consensusRegistry.getBlsPubkey(initialValidators[i].validatorAddress)));
+            assertTrue(
+                consensusRegistry.isValidator(consensusRegistry.getBlsPubkey(initialValidators[i].validatorAddress))
+            );
 
             EpochInfo memory info = consensusRegistry.getEpochInfo(uint32(i));
             for (uint256 j; j < 4; ++j) {
@@ -125,9 +129,9 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         consensusRegistry.mint(validator5);
 
         vm.prank(validator5);
-        consensusRegistry.stake{
-            value: stakeAmount_
-        }(validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig));
+        consensusRegistry.stake{ value: stakeAmount_ }(
+            validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig)
+        );
 
         assertEq(uint8(consensusRegistry.getValidator(validator5).currentStatus), uint8(ValidatorStatus.Staked));
 
@@ -143,14 +147,16 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         consensusRegistry.mint(validator5);
 
         vm.prank(validator5);
-        consensusRegistry.stake{
-            value: stakeAmount_
-        }(validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig));
+        consensusRegistry.stake{ value: stakeAmount_ }(
+            validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig)
+        );
 
         vm.prank(validator5);
         consensusRegistry.activate();
 
-        assertEq(uint8(consensusRegistry.getValidator(validator5).currentStatus), uint8(ValidatorStatus.PendingActivation));
+        assertEq(
+            uint8(consensusRegistry.getValidator(validator5).currentStatus), uint8(ValidatorStatus.PendingActivation)
+        );
 
         vm.expectEmit(true, true, true, true);
         emit ValidatorRegionUpdated(validator5, 4);
@@ -230,9 +236,9 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
                 validator5, PENDING_EPOCH, uint32(0), ValidatorStatus.Staked, false, uint8(0), uint8(0)
             ));
         vm.prank(validator5);
-        consensusRegistry.stake{
-            value: stakeAmount_
-        }(validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig));
+        consensusRegistry.stake{ value: stakeAmount_ }(
+            validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig)
+        );
 
         // Check validator information
         ValidatorInfo[] memory validators = consensusRegistry.getValidatorsInfo(ValidatorStatus.Staked);
@@ -270,9 +276,9 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             ));
 
         vm.prank(delegator);
-        consensusRegistry.delegateStake{
-            value: stakeAmount_
-        }(validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig), validator5, validatorSig);
+        consensusRegistry.delegateStake{ value: stakeAmount_ }(
+            validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig), validator5, validatorSig
+        );
 
         // Check validator information
         ValidatorInfo[] memory validators = consensusRegistry.getValidatorsInfo(ValidatorStatus.Staked);
@@ -307,9 +313,9 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         consensusRegistry.setNextCommitteeSize(5);
 
         vm.prank(validator5);
-        consensusRegistry.stake{
-            value: stakeAmount_
-        }(validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig));
+        consensusRegistry.stake{ value: stakeAmount_ }(
+            validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig)
+        );
 
         // activate validator5 -> PendingActivation (committee-eligible next epoch, but not in the Active set)
         uint256 numEligibleBefore = consensusRegistry.getEligibleValidatorCount();
@@ -318,7 +324,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         // per-status: the Active set is unchanged; validator5 joins the eligible pool as PendingActivation
         ValidatorInfo[] memory activeValidators = consensusRegistry.getValidatorsInfo(ValidatorStatus.Active);
-        ValidatorInfo[] memory pendingActivation = consensusRegistry.getValidatorsInfo(ValidatorStatus.PendingActivation);
+        ValidatorInfo[] memory pendingActivation =
+            consensusRegistry.getValidatorsInfo(ValidatorStatus.PendingActivation);
         uint256 numEligible = consensusRegistry.getEligibleValidatorCount();
         assertEq(numEligible, numEligibleBefore + 1);
         assertEq(activeValidators.length, numEligibleBefore);
@@ -355,9 +362,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         vm.prank(validator5);
         // an all-zero compressed pubkey is rejected by the registry's compressed-key flag check
         vm.expectRevert(IStakeManager.InvalidBLSPubkey.selector);
-        consensusRegistry.stake{
-            value: stakeAmount_
-        }(new bytes(96), IStakeManager.ProofOfPossession(new bytes(48)));
+        consensusRegistry.stake{ value: stakeAmount_ }(new bytes(96), IStakeManager.ProofOfPossession(new bytes(48)));
     }
 
     /// @notice EXP-001 regression: a key and its y-sign-flipped negation (same x) cannot both register.
@@ -383,7 +388,9 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         // x-keyed deduplication collapses the negation variant and rejects it
         vm.prank(attackerB);
         vm.expectRevert(DuplicateBLSPubkey.selector);
-        consensusRegistry.stake{ value: stakeAmount_ }(compressedNegPK, IStakeManager.ProofOfPossession(_blsDummySigFromSecret(99)));
+        consensusRegistry.stake{ value: stakeAmount_ }(
+            compressedNegPK, IStakeManager.ProofOfPossession(_blsDummySigFromSecret(99))
+        );
     }
 
     /// @notice A stored compressed key with a malformed compression/infinity flag is rejected by the
@@ -401,7 +408,9 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         infinityFlagged[0] = infinityFlagged[0] | bytes1(0x40);
         vm.prank(validator5);
         vm.expectRevert(IStakeManager.InvalidBLSPubkey.selector);
-        consensusRegistry.stake{ value: stakeAmount_ }(infinityFlagged, IStakeManager.ProofOfPossession(validator5BlsSig));
+        consensusRegistry.stake{ value: stakeAmount_ }(
+            infinityFlagged, IStakeManager.ProofOfPossession(validator5BlsSig)
+        );
 
         // compression flag cleared -> off-chain blst fails to decode
         bytes memory uncompressedFlagged = new bytes(96);
@@ -424,9 +433,13 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         vm.prank(validator5);
         vm.expectRevert(
-            abi.encodeWithSelector(IStakeManager.InvalidProofOfPossession.selector, IStakeManager.ProofOfPossession(new bytes(47)))
+            abi.encodeWithSelector(
+                IStakeManager.InvalidProofOfPossession.selector, IStakeManager.ProofOfPossession(new bytes(47))
+            )
         );
-        consensusRegistry.stake{ value: stakeAmount_ }(validator5BlsPubkey, IStakeManager.ProofOfPossession(new bytes(47)));
+        consensusRegistry.stake{ value: stakeAmount_ }(
+            validator5BlsPubkey, IStakeManager.ProofOfPossession(new bytes(47))
+        );
     }
 
     /// @notice An empty committee reverts cleanly (InvalidCommitteeSize), not an `_enforceSorting` panic.
@@ -452,8 +465,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         _assertSetInvariant();
     }
 
-
-
     // Test for incorrect stake amount
     function testRevert_stake_invalidStakeAmount() public {
         vm.startPrank(validator5);
@@ -470,9 +481,9 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint256 numActiveBefore = consensusRegistry.getEligibleValidatorCount();
 
         vm.prank(validator5);
-        consensusRegistry.stake{
-            value: stakeAmount_
-        }(validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig));
+        consensusRegistry.stake{ value: stakeAmount_ }(
+            validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig)
+        );
 
         // activate and conclude epoch to reach validator5 activationEpoch
         vm.prank(validator5);
@@ -499,13 +510,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         // Check event emission
         vm.expectEmit(true, true, true, true);
         emit ValidatorPendingExit(ValidatorInfo(
-                validator5,
-                activationEpoch,
-                PENDING_EPOCH,
-                ValidatorStatus.PendingExit,
-                false,
-                uint8(0),
-                uint8(0)
+                validator5, activationEpoch, PENDING_EPOCH, ValidatorStatus.PendingExit, false, uint8(0), uint8(0)
             ));
         // begin exit
         vm.prank(validator5);
@@ -552,9 +557,9 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         consensusRegistry.mint(validator5);
 
         vm.startPrank(validator5);
-        consensusRegistry.stake{
-            value: stakeAmount_
-        }(validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig));
+        consensusRegistry.stake{ value: stakeAmount_ }(
+            validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig)
+        );
 
         // Attempt to exit without being active
         vm.expectRevert(abi.encodeWithSelector(InvalidStatus.selector, ValidatorStatus.Staked));
@@ -594,13 +599,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         bytes memory validator1Pubkey = _blsDummyPubkeyFromSecret(1); // recreate validator1 blsPubkey
         vm.expectEmit(true, true, true, true);
         emit ValidatorExited(ValidatorInfo(
-                validator1,
-                uint32(0),
-                expectedExitEpoch,
-                ValidatorStatus.Exited,
-                false,
-                uint8(0),
-                uint8(0)
+                validator1, uint32(0), expectedExitEpoch, ValidatorStatus.Exited, false, uint8(0), uint8(0)
             ));
 
         vm.startPrank(sysAddress);
@@ -617,7 +616,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         vm.expectEmit(true, true, true, true);
         emit RewardsClaimed(validator1, stakeAmount_);
         vm.prank(validator1);
-        consensusRegistry.unstake(validator1);
+        consensusRegistry.unstake(validator1, false);
 
         // validator1 earned 4 epochs' rewards, split between 4 validators
         uint256 finalBalance = validator1.balance;
@@ -630,9 +629,9 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         // stake stake but never activate
         vm.startPrank(validator5);
-        consensusRegistry.stake{
-            value: stakeAmount_
-        }(validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig));
+        consensusRegistry.stake{ value: stakeAmount_ }(
+            validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig)
+        );
 
         uint256 initialBalance = validator5.balance;
         assertEq(initialBalance, 0);
@@ -640,7 +639,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         // unstake to abort activation
         vm.expectEmit(true, true, true, true);
         emit RewardsClaimed(validator5, stakeAmount_);
-        consensusRegistry.unstake(validator5);
+        consensusRegistry.unstake(validator5, false);
 
         vm.stopPrank();
 
@@ -658,7 +657,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         vm.prank(nonValidator);
         vm.expectRevert();
-        consensusRegistry.unstake(nonValidator);
+        consensusRegistry.unstake(nonValidator, false);
     }
 
     // Test for unstake by a validator who has not exited
@@ -668,18 +667,17 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         // stake and activate
         vm.startPrank(validator5);
-        consensusRegistry.stake{
-            value: stakeAmount_
-        }(validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig));
+        consensusRegistry.stake{ value: stakeAmount_ }(
+            validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig)
+        );
         consensusRegistry.activate();
 
         // Attempt to unstake without exiting
         bytes memory err = abi.encodeWithSelector(
-            IneligibleUnstake.selector,
-            ValidatorInfo(validator5, 1, 0, ValidatorStatus.PendingActivation, false, 0, 0)
+            IneligibleUnstake.selector, ValidatorInfo(validator5, 1, 0, ValidatorStatus.PendingActivation, false, 0, 0)
         );
         vm.expectRevert(err);
-        consensusRegistry.unstake(validator5);
+        consensusRegistry.unstake(validator5, false);
 
         vm.stopPrank();
     }
@@ -833,7 +831,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         emit ValidatorStakeVersionUpgraded(validator1, 0, newVersion, stakeAmount_, newStakeAmt);
 
         vm.prank(validator1);
-        consensusRegistry.upgradeValidatorStakeVersion{value: deficit}(validator1, newVersion);
+        consensusRegistry.upgradeValidatorStakeVersion{ value: deficit }(validator1, newVersion);
 
         // Verify state
         ValidatorInfo memory info = consensusRegistry.getValidator(validator1);
@@ -889,7 +887,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         consensusRegistry.mint(validator5);
 
         vm.prank(validator5);
-        consensusRegistry.stake{value: stakeAmount_}(
+        consensusRegistry.stake{ value: stakeAmount_ }(
             validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig)
         );
 
@@ -904,7 +902,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         vm.deal(validator5, deficit);
 
         vm.prank(validator5);
-        consensusRegistry.upgradeValidatorStakeVersion{value: deficit}(validator5, newVersion);
+        consensusRegistry.upgradeValidatorStakeVersion{ value: deficit }(validator5, newVersion);
 
         ValidatorInfo memory info = consensusRegistry.getValidator(validator5);
         assertEq(info.stakeVersion, newVersion);
@@ -926,7 +924,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         bytes memory validatorSig = abi.encodePacked(r, s, v);
 
         vm.prank(delegator);
-        consensusRegistry.delegateStake{value: stakeAmount_}(
+        consensusRegistry.delegateStake{ value: stakeAmount_ }(
             validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig), validator5, validatorSig
         );
 
@@ -987,7 +985,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         vm.deal(validator1, deficit);
 
         vm.prank(validator1);
-        consensusRegistry.upgradeValidatorStakeVersion{value: deficit}(validator1, newVersion);
+        consensusRegistry.upgradeValidatorStakeVersion{ value: deficit }(validator1, newVersion);
 
         // Rewards should be preserved
         uint256 rewardsAfter = consensusRegistry.getRewards(validator1);
@@ -1036,7 +1034,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         vm.prank(validator1);
         vm.expectRevert(abi.encodeWithSelector(IStakeManager.InvalidStakeAmount.selector, wrongAmount));
-        consensusRegistry.upgradeValidatorStakeVersion{value: wrongAmount}(validator1, newVersion);
+        consensusRegistry.upgradeValidatorStakeVersion{ value: wrongAmount }(validator1, newVersion);
     }
 
     function testRevert_upgradeValidatorStakeVersion_invalidVersion() public {
@@ -1170,7 +1168,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator1);
         assertEq(balAfter, newStakeAmt);
 
-        // getRewards() = 0 (rewards zeroed — this is expected/documented behavior)
+        // getRewards() = 0 (rewards zeroed - this is expected/documented behavior)
         // After version change, rewards = balance - newStakeAmount = 600k - 600k = 0
         uint256 rewardsAfter = consensusRegistry.getRewards(validator1);
         assertEq(rewardsAfter, 0);
@@ -1238,12 +1236,12 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint256 deficit = newStakeAmt - stakeAmount_;
         vm.deal(validator1, deficit);
         vm.prank(validator1);
-        consensusRegistry.upgradeValidatorStakeVersion{value: deficit}(validator1, newVersion);
+        consensusRegistry.upgradeValidatorStakeVersion{ value: deficit }(validator1, newVersion);
 
         // Allocate issuance and apply incentives, conclude epoch
         vm.deal(crOwner, epochIssuance_);
         vm.prank(crOwner);
-        consensusRegistry.allocateIssuance{value: epochIssuance_}();
+        consensusRegistry.allocateIssuance{ value: epochIssuance_ }();
 
         address[] memory committee = new address[](4);
         committee[0] = validator1;
@@ -1291,7 +1289,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint256 deficit = newStakeAmt - stakeAmount_;
         vm.deal(validator1, deficit);
         vm.prank(validator1);
-        consensusRegistry.upgradeValidatorStakeVersion{value: deficit}(validator1, newVersion);
+        consensusRegistry.upgradeValidatorStakeVersion{ value: deficit }(validator1, newVersion);
 
         // Slash 500k
         Slash[] memory slashes = new Slash[](1);
@@ -1324,7 +1322,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         vm.prank(crOwner);
         consensusRegistry.pause();
 
-        // Try upgrade — expect revert with EnforcedPause
+        // Try upgrade - expect revert with EnforcedPause
         vm.prank(validator1);
         vm.expectRevert(Pausable.EnforcedPause.selector);
         consensusRegistry.upgradeValidatorStakeVersion(validator1, newVersion);
@@ -1343,9 +1341,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
     function test_upgradeValidatorStakeVersion_zeroStakeVersion() public {
         // Create version with stakeAmount = 0
         vm.prank(crOwner);
-        uint8 newVersion = consensusRegistry.upgradeStakeVersion(
-            StakeConfig(0, minWithdrawAmount_, epochIssuance_, epochDuration_)
-        );
+        uint8 newVersion =
+            consensusRegistry.upgradeStakeVersion(StakeConfig(0, minWithdrawAmount_, epochIssuance_, epochDuration_));
 
         uint256 recipientBalBefore = validator1.balance;
 
@@ -1376,7 +1373,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint256 deficit1 = v1StakeAmt - stakeAmount_;
         vm.deal(validator1, deficit1);
         vm.prank(validator1);
-        consensusRegistry.upgradeValidatorStakeVersion{value: deficit1}(validator1, v1);
+        consensusRegistry.upgradeValidatorStakeVersion{ value: deficit1 }(validator1, v1);
 
         // Verify state after v0 -> v1
         ValidatorInfo memory info1 = consensusRegistry.getValidator(validator1);
@@ -1389,7 +1386,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint256 deficit2 = v2StakeAmt - v1StakeAmt;
         vm.deal(validator1, deficit2);
         vm.prank(validator1);
-        consensusRegistry.upgradeValidatorStakeVersion{value: deficit2}(validator1, v2);
+        consensusRegistry.upgradeValidatorStakeVersion{ value: deficit2 }(validator1, v2);
 
         // Verify state after v1 -> v2
         ValidatorInfo memory info2 = consensusRegistry.getValidator(validator1);
@@ -1417,7 +1414,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         bytes memory validatorSig = abi.encodePacked(r, s, v);
 
         vm.prank(delegator);
-        consensusRegistry.delegateStake{value: stakeAmount_}(
+        consensusRegistry.delegateStake{ value: stakeAmount_ }(
             validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig), validator5, validatorSig
         );
         assertTrue(consensusRegistry.isDelegated(validator5));
@@ -1451,7 +1448,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         // --- delegator unstakes ---
         vm.deal(address(consensusRegistry), stakeAmount_);
         vm.prank(delegator);
-        consensusRegistry.unstake(validator5);
+        consensusRegistry.unstake(validator5, false);
 
         // delegation must be cleared
         assertFalse(consensusRegistry.isDelegated(validator5));
@@ -1472,7 +1469,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         bytes memory validatorSig = abi.encodePacked(r, s, v);
 
         vm.prank(delegator);
-        consensusRegistry.delegateStake{value: stakeAmount_}(
+        consensusRegistry.delegateStake{ value: stakeAmount_ }(
             validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig), validator5, validatorSig
         );
         assertTrue(consensusRegistry.isDelegated(validator5));
@@ -1483,5 +1480,449 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         // delegation must be cleared
         assertFalse(consensusRegistry.isDelegated(validator5));
+    }
+
+    /*
+     *   slashing settlement & top-ups
+     */
+
+    /// @dev Partially slashes genesis `validator1` via system call
+    function _slashValidator1(uint256 amount) internal {
+        Slash[] memory slashes = new Slash[](1);
+        slashes[0] = Slash(validator1, amount);
+        vm.prank(sysAddress);
+        consensusRegistry.applySlashes(slashes);
+    }
+
+    /// @dev Exits genesis `validator1` through the pending-exit queue and elapses one further
+    /// epoch so it becomes unstake-eligible
+    function _exitValidator1ToUnstakeEligibility() internal {
+        uint256 numActive = consensusRegistry.getEligibleValidatorCount();
+
+        vm.prank(validator1);
+        consensusRegistry.beginExit();
+
+        // validator1 serves in the genesis committees for the first epochs, so conclude past them
+        vm.startPrank(sysAddress);
+        address[] memory waitCommittee = _createTokenIdCommittee(numActive);
+        waitCommittee[waitCommittee.length - 1] = validator1;
+        consensusRegistry.concludeEpoch(waitCommittee);
+        address[] memory tokenIdCommittee = _createTokenIdCommittee(numActive);
+        consensusRegistry.concludeEpoch(tokenIdCommittee);
+        consensusRegistry.concludeEpoch(tokenIdCommittee);
+        vm.stopPrank();
+
+        uint256 activeAfterExit = numActive - 1;
+        vm.prank(crOwner);
+        consensusRegistry.setNextCommitteeSize(uint16(activeAfterExit));
+
+        // exit resolves on the next epoch conclusion; one further epoch reaches unstake eligibility
+        vm.startPrank(sysAddress);
+        address[] memory afterExitCommittee = _createTokenIdCommittee(activeAfterExit);
+        consensusRegistry.concludeEpoch(afterExitCommittee);
+        consensusRegistry.concludeEpoch(afterExitCommittee);
+        vm.stopPrank();
+    }
+
+    function test_applySlashes_partial_consolidatesAtUnstake() public {
+        uint256 slashAmt = 200_000e18;
+        uint256 registryBalBefore = address(consensusRegistry).balance;
+        uint256 issuanceBalBefore = issuance.balance;
+
+        vm.expectEmit(true, true, true, true);
+        emit ValidatorSlashed(Slash(validator1, slashAmt));
+        _slashValidator1(slashAmt);
+
+        // a partial slash decrements only the balance ledger; no native TEL moves until settlement
+        (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator1);
+        assertEq(balAfter, stakeAmount_ - slashAmt);
+        assertEq(address(consensusRegistry).balance, registryBalBefore);
+        assertEq(issuance.balance, issuanceBalBefore);
+
+        // on unstake the slashed remainder consolidates on Issuance and the reduced stake returns
+        _exitValidator1ToUnstakeEligibility();
+        vm.prank(validator1);
+        consensusRegistry.unstake(validator1, false);
+
+        assertEq(validator1.balance, stakeAmount_ - slashAmt);
+        assertEq(issuance.balance, issuanceBalBefore + slashAmt);
+        assertEq(address(consensusRegistry).balance, registryBalBefore - stakeAmount_);
+    }
+
+    function test_applySlashes_fullSlash_consolidatesFullStake() public {
+        uint256 registryBalBefore = address(consensusRegistry).balance;
+        uint256 issuanceBalBefore = issuance.balance;
+
+        // a slash consuming the whole balance ejects the validator and confiscates its full stake
+        _slashValidator1(stakeAmount_);
+
+        assertTrue(consensusRegistry.isRetired(validator1));
+        (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator1);
+        assertEq(balAfter, 0);
+        assertEq(issuance.balance, issuanceBalBefore + stakeAmount_);
+        assertEq(address(consensusRegistry).balance, registryBalBefore - stakeAmount_);
+    }
+
+    function test_applySlashes_partialThenFull_noOrphanedFunds() public {
+        _slashValidator1(200_000e18);
+
+        uint256 registryBalBefore = address(consensusRegistry).balance;
+        uint256 issuanceBalBefore = issuance.balance;
+
+        // the second slash consumes the whole remaining balance, triggering ejection via burn
+        _slashValidator1(800_000e18);
+
+        assertTrue(consensusRegistry.isRetired(validator1));
+        // the full original stake consolidates on Issuance, including the earlier slashed portion
+        assertEq(issuance.balance, issuanceBalBefore + stakeAmount_);
+        assertEq(address(consensusRegistry).balance, registryBalBefore - stakeAmount_);
+    }
+
+    function test_burn_slashedValidator_noOrphanedFunds() public {
+        uint256 slashAmt = 200_000e18;
+        _slashValidator1(slashAmt);
+
+        uint256 registryBalBefore = address(consensusRegistry).balance;
+        uint256 issuanceBalBefore = issuance.balance;
+
+        // governance ejection confiscates the full stake-backed native, including the slashed portion
+        vm.prank(crOwner);
+        consensusRegistry.burn(validator1);
+
+        assertTrue(consensusRegistry.isRetired(validator1));
+        (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator1);
+        assertEq(balAfter, 0);
+        assertEq(validator1.balance, 0);
+        assertEq(issuance.balance, issuanceBalBefore + stakeAmount_);
+        assertEq(address(consensusRegistry).balance, registryBalBefore - stakeAmount_);
+    }
+
+    function test_applyIncentives_slashedValidatorWeightReduced() public {
+        // slash validator1 to half its stake; equal header counts should now yield unequal rewards
+        uint256 slashAmt = stakeAmount_ / 2;
+        _slashValidator1(slashAmt);
+
+        RewardInfo[] memory rewardInfos = new RewardInfo[](2);
+        rewardInfos[0] = RewardInfo(validator1, 10);
+        rewardInfos[1] = RewardInfo(validator2, 10);
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(rewardInfos);
+
+        // validator1's weight derives from its reduced balance, validator2's from its full stake
+        uint256 slashedWeight = (stakeAmount_ - slashAmt) * 10;
+        uint256 fullWeight = stakeAmount_ * 10;
+        uint256 totalWeight = slashedWeight + fullWeight;
+        uint256 expected1 = epochIssuance_ * slashedWeight / totalWeight;
+        uint256 expected2 = epochIssuance_ * fullWeight / totalWeight;
+
+        (uint256 bal1,,) = consensusRegistry.getBalanceBreakdown(validator1);
+        (uint256 bal2,,) = consensusRegistry.getBalanceBreakdown(validator2);
+        assertEq(bal1, stakeAmount_ - slashAmt + expected1);
+        assertEq(bal2, stakeAmount_ + expected2);
+        assertEq(consensusRegistry.getRewards(validator2), expected2);
+    }
+
+    function test_applyIncentives_rewardsDoNotIncreaseWeight() public {
+        // validator1 accrues rewards, pushing its balance above the stake amount
+        RewardInfo[] memory firstRound = new RewardInfo[](1);
+        firstRound[0] = RewardInfo(validator1, 10);
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(firstRound);
+        uint256 firstRoundRewards = consensusRegistry.getRewards(validator1);
+        assertEq(firstRoundRewards, epochIssuance_);
+
+        // second round: equal header counts for validator1 and validator2 yield equal rewards
+        // because weight is capped at the version's stake amount
+        RewardInfo[] memory secondRound = new RewardInfo[](2);
+        secondRound[0] = RewardInfo(validator1, 10);
+        secondRound[1] = RewardInfo(validator2, 10);
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(secondRound);
+
+        assertEq(consensusRegistry.getRewards(validator1), firstRoundRewards + epochIssuance_ / 2);
+        assertEq(consensusRegistry.getRewards(validator2), epochIssuance_ / 2);
+    }
+
+    /*
+     *   topUpSlashedStake
+     */
+
+    function test_topUpSlashedStake_validatorSelf() public {
+        uint256 slashAmt = 200_000e18;
+        _slashValidator1(slashAmt);
+
+        uint256 registryBalBefore = address(consensusRegistry).balance;
+        uint256 issuanceBalBefore = issuance.balance;
+
+        vm.deal(validator1, slashAmt);
+        vm.expectEmit(true, true, true, true);
+        emit ValidatorStakeToppedUp(validator1, slashAmt);
+        vm.prank(validator1);
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+
+        // the balance ledger is restored to the full stake amount
+        (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator1);
+        assertEq(balAfter, stakeAmount_);
+
+        // the top-up value consolidates on Issuance; the registry retains its stake-backed native
+        assertEq(issuance.balance, issuanceBalBefore + slashAmt);
+        assertEq(address(consensusRegistry).balance, registryBalBefore);
+    }
+
+    function test_topUpSlashedStake_ownerWhenAuthorityRequired() public {
+        uint256 slashAmt = 150_000e18;
+        _slashValidator1(slashAmt);
+
+        vm.prank(crOwner);
+        consensusRegistry.setTopUpAuthorityRequired(true);
+
+        vm.deal(crOwner, slashAmt);
+        vm.prank(crOwner);
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+
+        (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator1);
+        assertEq(balAfter, stakeAmount_);
+    }
+
+    function test_topUpSlashedStake_delegator() public {
+        // setup delegation for validator5
+        uint256 validator5PrivateKey = 5;
+        validator5 = vm.addr(validator5PrivateKey);
+        address delegator = _addressFromPrivateKey(42);
+        vm.deal(delegator, stakeAmount_);
+
+        vm.prank(crOwner);
+        consensusRegistry.mint(validator5);
+
+        bytes32 structHash = consensusRegistry.delegationDigest(validator5BlsPubkey, validator5, delegator);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(validator5PrivateKey, structHash);
+        bytes memory validatorSig = abi.encodePacked(r, s, v);
+
+        vm.prank(delegator);
+        consensusRegistry.delegateStake{ value: stakeAmount_ }(
+            validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig), validator5, validatorSig
+        );
+
+        // slash the staked validator5, then its delegator restores the stake
+        uint256 slashAmt = 100_000e18;
+        Slash[] memory slashes = new Slash[](1);
+        slashes[0] = Slash(validator5, slashAmt);
+        vm.prank(sysAddress);
+        consensusRegistry.applySlashes(slashes);
+
+        vm.deal(delegator, slashAmt);
+        vm.prank(delegator);
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator5);
+
+        (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator5);
+        assertEq(balAfter, stakeAmount_);
+    }
+
+    function test_topUpSlashedStake_thenUnstake_noOrphanedFunds() public {
+        uint256 slashAmt = 200_000e18;
+        _slashValidator1(slashAmt);
+
+        // top up, restoring the ledger; the deficit consolidates on Issuance
+        vm.deal(validator1, slashAmt);
+        vm.prank(validator1);
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+
+        _exitValidator1ToUnstakeEligibility();
+
+        uint256 registryBalBefore = address(consensusRegistry).balance;
+        uint256 issuanceBalBefore = issuance.balance;
+
+        vm.prank(validator1);
+        consensusRegistry.unstake(validator1, false);
+
+        // the full stake returns and no native TEL is left stranded on the registry
+        assertEq(validator1.balance, stakeAmount_);
+        assertEq(address(consensusRegistry).balance, registryBalBefore - stakeAmount_);
+        assertEq(issuance.balance, issuanceBalBefore);
+    }
+
+    function testRevert_topUpSlashedStake_authorityRequired() public {
+        uint256 slashAmt = 100_000e18;
+        _slashValidator1(slashAmt);
+
+        vm.prank(crOwner);
+        consensusRegistry.setTopUpAuthorityRequired(true);
+
+        vm.deal(validator1, slashAmt);
+        vm.prank(validator1);
+        vm.expectRevert(TopUpAuthorityRequired.selector);
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+    }
+
+    function testRevert_topUpSlashedStake_notRecipient() public {
+        uint256 slashAmt = 100_000e18;
+        _slashValidator1(slashAmt);
+
+        address thirdParty = address(0xbeef);
+        vm.deal(thirdParty, slashAmt);
+        vm.prank(thirdParty);
+        vm.expectRevert(abi.encodeWithSelector(IStakeManager.NotRecipient.selector, validator1));
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+    }
+
+    function testRevert_topUpSlashedStake_notSlashed() public {
+        vm.deal(validator1, 1);
+        vm.prank(validator1);
+        vm.expectRevert(abi.encodeWithSelector(StakeNotSlashed.selector, validator1, stakeAmount_, uint8(0)));
+        consensusRegistry.topUpSlashedStake{ value: 1 }(validator1);
+    }
+
+    function testRevert_topUpSlashedStake_wrongValue() public {
+        uint256 slashAmt = 100_000e18;
+        _slashValidator1(slashAmt);
+
+        uint256 wrongValue = slashAmt - 1;
+        vm.deal(validator1, wrongValue);
+        vm.prank(validator1);
+        vm.expectRevert(abi.encodeWithSelector(InvalidDeficitAmount.selector, validator1, wrongValue, uint8(0)));
+        consensusRegistry.topUpSlashedStake{ value: wrongValue }(validator1);
+    }
+
+    function testRevert_topUpSlashedStake_invalidStatus() public {
+        uint256 slashAmt = 100_000e18;
+        _slashValidator1(slashAmt);
+
+        // pending-exit validators may not top up
+        vm.prank(validator1);
+        consensusRegistry.beginExit();
+
+        vm.deal(validator1, slashAmt);
+        vm.prank(validator1);
+        vm.expectRevert(abi.encodeWithSelector(InvalidStatus.selector, ValidatorStatus.PendingExit));
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+    }
+
+    function testRevert_topUpSlashedStake_unknownValidator() public {
+        address unknown = address(0xabc);
+        vm.deal(unknown, 1 ether);
+        vm.prank(unknown);
+        vm.expectRevert(abi.encodeWithSelector(IStakeManager.InvalidTokenId.selector, _getTokenId(unknown)));
+        consensusRegistry.topUpSlashedStake{ value: 1 ether }(unknown);
+    }
+
+    function testRevert_topUpSlashedStake_paused() public {
+        uint256 slashAmt = 100_000e18;
+        _slashValidator1(slashAmt);
+
+        vm.prank(crOwner);
+        consensusRegistry.pause();
+
+        vm.deal(validator1, slashAmt);
+        vm.prank(validator1);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+    }
+
+    function test_setTopUpAuthorityRequired() public {
+        assertFalse(consensusRegistry.topUpAuthorityRequired());
+
+        vm.expectEmit(true, true, true, true);
+        emit TopUpAuthorityRequirementUpdated(true);
+        vm.prank(crOwner);
+        consensusRegistry.setTopUpAuthorityRequired(true);
+        assertTrue(consensusRegistry.topUpAuthorityRequired());
+
+        vm.prank(crOwner);
+        consensusRegistry.setTopUpAuthorityRequired(false);
+        assertFalse(consensusRegistry.topUpAuthorityRequired());
+    }
+
+    function testRevert_setTopUpAuthorityRequired_notOwner() public {
+        vm.prank(validator1);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUnauthorizedAccount.selector, validator1));
+        consensusRegistry.setTopUpAuthorityRequired(true);
+    }
+
+    /*
+     *   issuanceWithdrawal & emergency exit
+     */
+
+    function test_issuanceWithdrawal() public {
+        uint256 amount = 10_000e18;
+        uint256 issuanceBalBefore = issuance.balance;
+        uint256 ownerBalBefore = crOwner.balance;
+
+        vm.prank(crOwner);
+        consensusRegistry.issuanceWithdrawal(amount);
+
+        assertEq(issuance.balance, issuanceBalBefore - amount);
+        assertEq(crOwner.balance, ownerBalBefore + amount);
+    }
+
+    function testRevert_issuanceWithdrawal_notOwner() public {
+        vm.prank(validator1);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUnauthorizedAccount.selector, validator1));
+        consensusRegistry.issuanceWithdrawal(1);
+    }
+
+    function testRevert_issuanceWithdrawal_insufficientBalance() public {
+        uint256 available = issuance.balance;
+        vm.prank(crOwner);
+        vm.expectRevert(abi.encodeWithSelector(Issuance.InsufficientBalance.selector, available, available + 1));
+        consensusRegistry.issuanceWithdrawal(available + 1);
+    }
+
+    function testRevert_issuanceWithdraw_onlyStakeManager() public {
+        vm.prank(crOwner);
+        vm.expectRevert(abi.encodeWithSelector(Issuance.OnlyStakeManager.selector, address(consensusRegistry)));
+        Issuance(issuance).withdraw(1, crOwner);
+    }
+
+    function test_unstake_emergencyExit_forfeitsRewards() public {
+        // validator1 accrues rewards
+        RewardInfo[] memory rewardInfos = new RewardInfo[](1);
+        rewardInfos[0] = RewardInfo(validator1, 10);
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(rewardInfos);
+        uint256 accrued = consensusRegistry.getRewards(validator1);
+        assertGt(accrued, 0);
+
+        _exitValidator1ToUnstakeEligibility();
+
+        uint256 issuanceBalBefore = issuance.balance;
+
+        // an emergency exit returns the stake but permanently forfeits the accrued rewards
+        vm.expectEmit(true, true, true, true);
+        emit RewardsClaimed(validator1, stakeAmount_);
+        vm.prank(validator1);
+        consensusRegistry.unstake(validator1, true);
+
+        assertEq(validator1.balance, stakeAmount_);
+        assertTrue(consensusRegistry.isRetired(validator1));
+        // the forfeited rewards remain in the Issuance reward pool
+        assertEq(issuance.balance, issuanceBalBefore);
+    }
+
+    function test_unstake_emergencyExit_insufficientIssuanceBalance() public {
+        // validator1 accrues rewards
+        RewardInfo[] memory rewardInfos = new RewardInfo[](1);
+        rewardInfos[0] = RewardInfo(validator1, 10);
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(rewardInfos);
+        uint256 accrued = consensusRegistry.getRewards(validator1);
+        assertGt(accrued, 0);
+
+        _exitValidator1ToUnstakeEligibility();
+
+        // drain the reward pool so accrued rewards can no longer be paid out
+        vm.prank(crOwner);
+        consensusRegistry.issuanceWithdrawal(issuance.balance);
+
+        // a normal unstake cannot cover the rewards owed and reverts
+        vm.prank(validator1);
+        vm.expectRevert(
+            abi.encodeWithSelector(Issuance.InsufficientBalance.selector, stakeAmount_, stakeAmount_ + accrued)
+        );
+        consensusRegistry.unstake(validator1, false);
+
+        // the emergency exit path still returns the stake
+        vm.prank(validator1);
+        consensusRegistry.unstake(validator1, true);
+        assertEq(validator1.balance, stakeAmount_);
     }
 }


### PR DESCRIPTION
## Summary

Five changes from the audit-findings list, plus settlement-accounting fixes that surfaced while wiring them together:

- **Slash-aware reward weights**: `applyIncentives` now derives each validator's weight from its effective stake - the version's stake amount, capped to the outstanding balance when slashes have reduced it below that amount. Rewards above the stake amount never add weight.
- **Slashed-stake top-ups**: new `topUpSlashedStake` restores a slashed validator's balance ledger to the full stake amount. The exact deficit must be provided as `msg.value`. A `topUpAuthorityRequired` toggle (governance-settable via `setTopUpAuthorityRequired`) restricts top-ups to governance; while it is off, the validator or its delegator may self-serve. Governance may always top up.
- **Issuance withdrawal**: new `Issuance.withdraw` plus a governance-gated `issuanceWithdrawal` on the registry, allowing recovery of consolidated slash funds and prior issuance allocations.
- **Emergency exit**: `unstake` takes an `emergencyExit` flag that permanently forfeits accrued rewards and returns only the stake balance, so a validator can still exit when the Issuance balance cannot cover the rewards owed. The `RewardsClaimed` amount reflects the forfeiture.
- **No orphaned slash funds**: `_consensusBurn` now consolidates the validator's entire stake-backed native TEL on Issuance. Previously it moved only `min(outstandingBalance, initialStake)`, so burning a partially slashed validator stranded the slashed remainder on the registry permanently.

## Design note: when slashed native TEL moves

The registry holds exactly `stakeAmount` native TEL per staked validator; reward balances are ledger entries backed by the Issuance pool. We kept partial slashes as ledger-only decrements and instead consolidate the confiscated native on Issuance at settlement:

- top-up: the deficit `msg.value` is forwarded straight to Issuance (the registry already holds the full stake-backed native)
- unstake: the existing `stakeAmt - bal` consolidation
- burn / slash-to-zero: the full `initialStakeAmt` (the orphan fix above)

An earlier draft moved `slash.amount` of native to Issuance inside `applySlashes` itself. That double-counts against the settlement paths (`_unstake` and the `upgradeValidatorStakeVersion` downgrade path would consolidate the same funds again, draining native belonging to other validators) and over-sends when a slash overlaps accrued rewards, whose native lives on Issuance rather than the registry. Settlement-time consolidation preserves the single invariant every money path already assumes, and keeps `applySlashes` free of per-slash external calls on the system-call hot path. The only timing difference is when the confiscated TEL becomes part of the reward pool, and governance can always rebalance via `allocateIssuance` / `issuanceWithdrawal`.

`topUpSlashedStake` access control is enforced in the direction the flag name implies: with `topUpAuthorityRequired` on, only governance may top up; with it off, the stake originator (validator or delegator) may as well. Third parties can never top up.

## Comment/doc updates

- `Issuance` and `allocateIssuance` natspec no longer claim allocated TEL is unrecoverable (superseded by `issuanceWithdrawal`)
- completed/added natspec for the new errors, events, and functions in both interfaces
- the `applyIncentives` weight comment now describes the balance-capped derivation

## Testing

25 new tests covering: partial-slash ledger semantics and settlement consolidation, full-slash and partial-then-full burn fund flows, burn of a slashed validator (orphan regression), slash-reduced reward weights and the stake-amount weight cap, top-up happy paths (self, owner-with-flag, delegator), the full slash -> top-up -> unstake round trip, all top-up revert paths (authority flag, non-recipient, not slashed, wrong value, bad status, unknown validator, paused), the authority toggle, issuance withdrawal (happy, non-owner, insufficient balance, direct-call gate), and emergency exit (reward forfeiture, and exit with a drained reward pool where normal unstake reverts).

Full suite: 243 passed, 0 failed (fast profile).

## Merge-order note

PR #134 touches the same regions (`IStakeManager.unstake`, the `delegateStake` surroundings, and the delegated test fixtures) and will need a small rebase whichever lands second. PRs #132, #133, and #135 do not overlap; #135's new ejection tests compile unchanged against this branch's `unstake` signature since they never call it.