### PR TITLE
fix(consensus): consolidate full initial stake on Issuance during validator burn

### DIFF
--- a/src/consensus/ConsensusRegistry.sol
+++ b/src/consensus/ConsensusRegistry.sol
@@ -140,6 +140,8 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
             if (isRetired(slash.validatorAddress)) continue;
 
             if (balances[slash.validatorAddress] > slash.amount) {
+                // ledger-only decrement: the confiscated native TEL remains held by this contract
+                // and is consolidated on Issuance at settlement (unstake or burn)
                 balances[slash.validatorAddress] -= slash.amount;
             } else {
                 // eject validators whose balance would reach 0
@@ -951,13 +953,13 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         _ejectFromCommittees(validatorAddress, numEligible);
 
         // settle ledgers
-        (uint256 outstandingBalance, uint256 initialStakeAmt,) = getBalanceBreakdown(validatorAddress);
+        (, uint256 initialStakeAmt,) = getBalanceBreakdown(validatorAddress);
         // rewards are already held on Issuance contract, so wiping registry's balance ledger effectively confiscates
         // them
         balances[validatorAddress] = 0;
-        // confiscate outstanding stake balance by consolidating it on the Issuance contract
-        uint256 confiscatedStake = outstandingBalance < initialStakeAmt ? outstandingBalance : initialStakeAmt;
-        (bool r,) = issuance.call{ value: confiscatedStake }("");
+        // confiscate the validator's entire stake-backed native TEL, including any previously
+        // slashed remainder still held by this contract, by consolidating it on Issuance
+        (bool r,) = issuance.call{ value: initialStakeAmt }("");
         // this is believed to be impossible
         if (!r) revert IssuanceTransferFailed();
 

--- a/test/consensus/ConsensusRegistryTest.t.sol
+++ b/test/consensus/ConsensusRegistryTest.t.sol
@@ -1484,4 +1484,119 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         // delegation must be cleared
         assertFalse(consensusRegistry.isDelegated(validator5));
     }
+
+    /*
+     *   slashing settlement
+     */
+
+    /// @dev Partially slashes genesis `validator1` via system call
+    function _slashValidator1(uint256 amount) internal {
+        Slash[] memory slashes = new Slash[](1);
+        slashes[0] = Slash(validator1, amount);
+        vm.prank(sysAddress);
+        consensusRegistry.applySlashes(slashes);
+    }
+
+    /// @dev Exits genesis `validator1` through the pending-exit queue and elapses one further
+    /// epoch so it becomes unstake-eligible
+    function _exitValidator1ToUnstakeEligibility() internal {
+        uint256 numActive = consensusRegistry.getEligibleValidatorCount();
+
+        vm.prank(validator1);
+        consensusRegistry.beginExit();
+
+        // validator1 serves in the genesis committees for the first epochs, so conclude past them
+        vm.startPrank(sysAddress);
+        address[] memory waitCommittee = _createTokenIdCommittee(numActive);
+        waitCommittee[waitCommittee.length - 1] = validator1;
+        consensusRegistry.concludeEpoch(waitCommittee);
+        address[] memory tokenIdCommittee = _createTokenIdCommittee(numActive);
+        consensusRegistry.concludeEpoch(tokenIdCommittee);
+        consensusRegistry.concludeEpoch(tokenIdCommittee);
+        vm.stopPrank();
+
+        uint256 activeAfterExit = numActive - 1;
+        vm.prank(crOwner);
+        consensusRegistry.setNextCommitteeSize(uint16(activeAfterExit));
+
+        // exit resolves on the next epoch conclusion; one further epoch reaches unstake eligibility
+        vm.startPrank(sysAddress);
+        address[] memory afterExitCommittee = _createTokenIdCommittee(activeAfterExit);
+        consensusRegistry.concludeEpoch(afterExitCommittee);
+        consensusRegistry.concludeEpoch(afterExitCommittee);
+        vm.stopPrank();
+    }
+
+    function test_applySlashes_partial_consolidatesAtUnstake() public {
+        uint256 slashAmt = 200_000e18;
+        uint256 registryBalBefore = address(consensusRegistry).balance;
+        uint256 issuanceBalBefore = issuance.balance;
+
+        vm.expectEmit(true, true, true, true);
+        emit ValidatorSlashed(Slash(validator1, slashAmt));
+        _slashValidator1(slashAmt);
+
+        // a partial slash decrements only the balance ledger; no native TEL moves until settlement
+        (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator1);
+        assertEq(balAfter, stakeAmount_ - slashAmt);
+        assertEq(address(consensusRegistry).balance, registryBalBefore);
+        assertEq(issuance.balance, issuanceBalBefore);
+
+        // on unstake the slashed remainder consolidates on Issuance and the reduced stake returns
+        _exitValidator1ToUnstakeEligibility();
+        vm.prank(validator1);
+        consensusRegistry.unstake(validator1);
+
+        assertEq(validator1.balance, stakeAmount_ - slashAmt);
+        assertEq(issuance.balance, issuanceBalBefore + slashAmt);
+        assertEq(address(consensusRegistry).balance, registryBalBefore - stakeAmount_);
+    }
+
+    function test_applySlashes_fullSlash_consolidatesFullStake() public {
+        uint256 registryBalBefore = address(consensusRegistry).balance;
+        uint256 issuanceBalBefore = issuance.balance;
+
+        // a slash consuming the whole balance ejects the validator and confiscates its full stake
+        _slashValidator1(stakeAmount_);
+
+        assertTrue(consensusRegistry.isRetired(validator1));
+        (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator1);
+        assertEq(balAfter, 0);
+        assertEq(issuance.balance, issuanceBalBefore + stakeAmount_);
+        assertEq(address(consensusRegistry).balance, registryBalBefore - stakeAmount_);
+    }
+
+    function test_applySlashes_partialThenFull_noOrphanedFunds() public {
+        _slashValidator1(200_000e18);
+
+        uint256 registryBalBefore = address(consensusRegistry).balance;
+        uint256 issuanceBalBefore = issuance.balance;
+
+        // the second slash consumes the whole remaining balance, triggering ejection via burn
+        _slashValidator1(800_000e18);
+
+        assertTrue(consensusRegistry.isRetired(validator1));
+        // the full original stake consolidates on Issuance, including the earlier slashed portion
+        assertEq(issuance.balance, issuanceBalBefore + stakeAmount_);
+        assertEq(address(consensusRegistry).balance, registryBalBefore - stakeAmount_);
+    }
+
+    function test_burn_slashedValidator_noOrphanedFunds() public {
+        uint256 slashAmt = 200_000e18;
+        _slashValidator1(slashAmt);
+
+        uint256 registryBalBefore = address(consensusRegistry).balance;
+        uint256 issuanceBalBefore = issuance.balance;
+
+        // governance ejection confiscates the full stake-backed native, including the slashed portion
+        vm.prank(crOwner);
+        consensusRegistry.burn(validator1);
+
+        assertTrue(consensusRegistry.isRetired(validator1));
+        (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator1);
+        assertEq(balAfter, 0);
+        assertEq(validator1.balance, 0);
+        assertEq(issuance.balance, issuanceBalBefore + stakeAmount_);
+        assertEq(address(consensusRegistry).balance, registryBalBefore - stakeAmount_);
+    }
 }


### PR DESCRIPTION
## Finding

Cantina review, rated Medium. Previously slashed stake can remain stranded after a validator burn.

The registry holds exactly the stake amount of native TEL per staked validator; a slash decrements only the balance ledger, leaving the confiscated native TEL in the contract until settlement. `_consensusBurn` settled with `min(outstandingBalance, initialStakeAmt)`, so for a partially slashed validator only the reduced ledger balance moved to Issuance and the slashed remainder stayed on the registry with no code path that could ever move it - stranded permanently. Reachable by both governance ejection of a slashed validator and a final slash that follows an earlier partial slash.

## Fix

`_consensusBurn` now consolidates the full `initialStakeAmt` on the Issuance contract, covering both the wiped ledger balance and any previously slashed remainder still held by the registry. A comment on `applySlashes`'s partial branch documents the ledger-only decrement and settlement-time consolidation it relies on.

## Tests

Four additions covering the slash-settlement money flow end to end:

- `test_applySlashes_partial_consolidatesAtUnstake`: a partial slash moves no native TEL; the remainder consolidates on Issuance at unstake
- `test_applySlashes_fullSlash_consolidatesFullStake`: slash-to-zero ejection confiscates the full stake
- `test_applySlashes_partialThenFull_noOrphanedFunds`: partial then final slash leaves nothing stranded
- `test_burn_slashedValidator_noOrphanedFunds`: governance burn of a slashed validator leaves nothing stranded

The last two fail against the prior implementation (verified by temporarily restoring the `min` settlement: each strands the 200k slashed remainder). Full suite: 222 passed, 0 failed, 2 skipped.

Closes #142.
