### PR TITLE
fix(consensus): emergency exit path so reward underfunding cannot block unstaking

### DIFF
--- a/src/consensus/ConsensusRegistry.sol
+++ b/src/consensus/ConsensusRegistry.sol
@@ -552,7 +552,7 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
             if (refundAmount > 0) {
                 balances[validatorAddress] -= refundAmount;
                 // Route through Issuance (same pattern as _unstake)
-                Issuance(issuance).distributeStakeReward{ value: refundAmount }(recipient, 0, false);
+                Issuance(issuance).distributeStakeReward{ value: refundAmount }(recipient, 0);
             }
 
             // consolidate confiscated slash remainder on Issuance (same as _unstake pattern)
@@ -610,7 +610,7 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         // permanently retire the validator and burn the ConsensusNFT
         _retire(validator);
 
-        // return stake and send any outstanding rewards unless forfeited via emergency exit
+        // return stake plus rewards; an emergency exit forfeits only rewards Issuance cannot cover
         uint256 stakeAndRewards = _unstake(validatorAddress, recipient, emergencyExit);
 
         emit RewardsClaimed(recipient, stakeAndRewards);

--- a/src/consensus/ConsensusRegistry.sol
+++ b/src/consensus/ConsensusRegistry.sol
@@ -552,7 +552,7 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
             if (refundAmount > 0) {
                 balances[validatorAddress] -= refundAmount;
                 // Route through Issuance (same pattern as _unstake)
-                Issuance(issuance).distributeStakeReward{ value: refundAmount }(recipient, 0);
+                Issuance(issuance).distributeStakeReward{ value: refundAmount }(recipient, 0, false);
             }
 
             // consolidate confiscated slash remainder on Issuance (same as _unstake pattern)
@@ -599,7 +599,7 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
     }
 
     /// @inheritdoc StakeManager
-    function unstake(address validatorAddress) external override whenNotPaused nonReentrant {
+    function unstake(address validatorAddress, bool emergencyExit) external override whenNotPaused nonReentrant {
         // require validator holds a ConsensusNFT and the caller is the validator or its delegator
         address recipient = _checkStakeOriginator(validatorAddress);
 
@@ -610,8 +610,8 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         // permanently retire the validator and burn the ConsensusNFT
         _retire(validator);
 
-        // return stake and send any outstanding rewards
-        uint256 stakeAndRewards = _unstake(validatorAddress, recipient);
+        // return stake and send any outstanding rewards unless forfeited via emergency exit
+        uint256 stakeAndRewards = _unstake(validatorAddress, recipient, emergencyExit);
 
         emit RewardsClaimed(recipient, stakeAndRewards);
     }
@@ -965,7 +965,7 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         _exit(validator, currentEpoch);
         _retire(validator);
         address recipient = _getRecipient(validatorAddress);
-        _unstake(validatorAddress, recipient);
+        _unstake(validatorAddress, recipient, true);
     }
 
     /// @dev Stores the number of blocks finalized in previous epoch and the voter committee for the new epoch

--- a/src/consensus/ConsensusRegistry.sol
+++ b/src/consensus/ConsensusRegistry.sol
@@ -599,7 +599,7 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
     }
 
     /// @inheritdoc StakeManager
-    function unstake(address validatorAddress, bool emergencyExit) external override whenNotPaused nonReentrant {
+    function unstake(address validatorAddress, bool acceptRewardShortfall) external override whenNotPaused nonReentrant {
         // require validator holds a ConsensusNFT and the caller is the validator or its delegator
         address recipient = _checkStakeOriginator(validatorAddress);
 
@@ -610,8 +610,8 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         // permanently retire the validator and burn the ConsensusNFT
         _retire(validator);
 
-        // return stake plus rewards; an emergency exit forfeits only rewards Issuance cannot cover
-        uint256 stakeAndRewards = _unstake(validatorAddress, recipient, emergencyExit);
+        // return stake plus rewards; accepting a reward shortfall forfeits only rewards Issuance cannot cover
+        uint256 stakeAndRewards = _unstake(validatorAddress, recipient, acceptRewardShortfall);
 
         emit RewardsClaimed(recipient, stakeAndRewards);
     }

--- a/src/consensus/Issuance.sol
+++ b/src/consensus/Issuance.sol
@@ -24,9 +24,20 @@ contract Issuance {
 
     /// @notice May only be called by StakeManager as part of claim, unstake or burn flow
     /// @dev Sends `rewardAmount` and forwards `msg.value` if stake amount is additionally provided
-    function distributeStakeReward(address recipient, uint256 rewardAmount) external payable virtual onlyStakeManager {
+    /// @param emergencyExit When true, forfeits `rewardAmount` and forwards only `msg.value`, so a
+    /// stake withdrawal can proceed even when this contract's balance cannot cover accrued rewards
+    function distributeStakeReward(
+        address recipient,
+        uint256 rewardAmount,
+        bool emergencyExit
+    )
+        external
+        payable
+        virtual
+        onlyStakeManager
+    {
         uint256 bal = address(this).balance;
-        uint256 totalAmount = rewardAmount + msg.value;
+        uint256 totalAmount = emergencyExit ? msg.value : rewardAmount + msg.value;
         if (bal < totalAmount) {
             revert InsufficientBalance(bal, totalAmount);
         }

--- a/src/consensus/Issuance.sol
+++ b/src/consensus/Issuance.sol
@@ -24,20 +24,9 @@ contract Issuance {
 
     /// @notice May only be called by StakeManager as part of claim, unstake or burn flow
     /// @dev Sends `rewardAmount` and forwards `msg.value` if stake amount is additionally provided
-    /// @param emergencyExit When true, forfeits `rewardAmount` and forwards only `msg.value`, so a
-    /// stake withdrawal can proceed even when this contract's balance cannot cover accrued rewards
-    function distributeStakeReward(
-        address recipient,
-        uint256 rewardAmount,
-        bool emergencyExit
-    )
-        external
-        payable
-        virtual
-        onlyStakeManager
-    {
+    function distributeStakeReward(address recipient, uint256 rewardAmount) external payable virtual onlyStakeManager {
         uint256 bal = address(this).balance;
-        uint256 totalAmount = emergencyExit ? msg.value : rewardAmount + msg.value;
+        uint256 totalAmount = rewardAmount + msg.value;
         if (bal < totalAmount) {
             revert InsufficientBalance(bal, totalAmount);
         }

--- a/src/consensus/StakeManager.sol
+++ b/src/consensus/StakeManager.sol
@@ -189,7 +189,7 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
         // check rewards are claimable and send via the Issuance contract
         uint256 rewards = _checkRewards(validatorAddress, validatorVersion);
         balances[validatorAddress] -= rewards;
-        Issuance(issuance).distributeStakeReward(recipient, rewards, false);
+        Issuance(issuance).distributeStakeReward(recipient, rewards);
 
         return rewards;
     }
@@ -227,11 +227,14 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
             if (!r) revert IssuanceTransferFailed();
         }
 
-        // debit `unstakeAmt` due to recipient from this contract balance, debit rewards from Issuance
-        // balance unless the recipient opted to forfeit rewards via emergency exit
-        Issuance(issuance).distributeStakeReward{ value: unstakeAmt }(recipient, rewards, emergencyExit);
+        // an emergency exit caps the rewards leg at what Issuance can cover, forfeiting only the
+        // shortfall, so an underfunded reward pool can never block a stake withdrawal
+        if (emergencyExit && rewards > issuance.balance) rewards = issuance.balance;
 
-        return emergencyExit ? unstakeAmt : unstakeAmt + rewards;
+        // debit `unstakeAmt` due to recipient from this contract balance, debit rewards from Issuance balance
+        Issuance(issuance).distributeStakeReward{ value: unstakeAmt }(recipient, rewards);
+
+        return unstakeAmt + rewards;
     }
 
     function _checkRewards(address validatorAddress, uint8 validatorVersion) internal virtual returns (uint256) {

--- a/src/consensus/StakeManager.sol
+++ b/src/consensus/StakeManager.sol
@@ -62,7 +62,7 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
     function claimStakeRewards(address ecsdaPubkey) external virtual;
 
     /// @inheritdoc IStakeManager
-    function unstake(address validatorAddress) external virtual;
+    function unstake(address validatorAddress, bool emergencyExit) external virtual;
 
     /// @inheritdoc IStakeManager
     function getRewards(address validatorAddress) public view virtual returns (uint256);
@@ -189,12 +189,20 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
         // check rewards are claimable and send via the Issuance contract
         uint256 rewards = _checkRewards(validatorAddress, validatorVersion);
         balances[validatorAddress] -= rewards;
-        Issuance(issuance).distributeStakeReward(recipient, rewards);
+        Issuance(issuance).distributeStakeReward(recipient, rewards, false);
 
         return rewards;
     }
 
-    function _unstake(address validatorAddress, address recipient) internal virtual returns (uint256) {
+    function _unstake(
+        address validatorAddress,
+        address recipient,
+        bool emergencyExit
+    )
+        internal
+        virtual
+        returns (uint256)
+    {
         _burn(_getTokenId(validatorAddress));
         if (totalSupply() == 0) revert InvalidSupply();
 
@@ -219,10 +227,11 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
             if (!r) revert IssuanceTransferFailed();
         }
 
-        // debit `unstakeAmt` due to recipient from this contract balance, debit rewards from Issuance balance
-        Issuance(issuance).distributeStakeReward{ value: unstakeAmt }(recipient, rewards);
+        // debit `unstakeAmt` due to recipient from this contract balance, debit rewards from Issuance
+        // balance unless the recipient opted to forfeit rewards via emergency exit
+        Issuance(issuance).distributeStakeReward{ value: unstakeAmt }(recipient, rewards, emergencyExit);
 
-        return unstakeAmt + rewards;
+        return emergencyExit ? unstakeAmt : unstakeAmt + rewards;
     }
 
     function _checkRewards(address validatorAddress, uint8 validatorVersion) internal virtual returns (uint256) {

--- a/src/consensus/StakeManager.sol
+++ b/src/consensus/StakeManager.sol
@@ -62,7 +62,7 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
     function claimStakeRewards(address ecsdaPubkey) external virtual;
 
     /// @inheritdoc IStakeManager
-    function unstake(address validatorAddress, bool emergencyExit) external virtual;
+    function unstake(address validatorAddress, bool acceptRewardShortfall) external virtual;
 
     /// @inheritdoc IStakeManager
     function getRewards(address validatorAddress) public view virtual returns (uint256);
@@ -197,7 +197,7 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
     function _unstake(
         address validatorAddress,
         address recipient,
-        bool emergencyExit
+        bool acceptRewardShortfall
     )
         internal
         virtual
@@ -227,9 +227,9 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
             if (!r) revert IssuanceTransferFailed();
         }
 
-        // an emergency exit caps the rewards leg at what Issuance can cover, forfeiting only the
+        // accepting a reward shortfall caps the rewards leg at what Issuance can cover, forfeiting only the
         // shortfall, so an underfunded reward pool can never block a stake withdrawal
-        if (emergencyExit && rewards > issuance.balance) rewards = issuance.balance;
+        if (acceptRewardShortfall && rewards > issuance.balance) rewards = issuance.balance;
 
         // debit `unstakeAmt` due to recipient from this contract balance, debit rewards from Issuance balance
         Issuance(issuance).distributeStakeReward{ value: unstakeAmt }(recipient, rewards);

--- a/src/interfaces/IStakeManager.sol
+++ b/src/interfaces/IStakeManager.sol
@@ -129,8 +129,9 @@ interface IStakeManager {
     /// @dev Returns previously staked funds in addition to accrued rewards, if any, to the staker
     /// @notice May be used to reverse validator onboarding pre-activation or permanently retire after full exit
     /// @notice Once unstaked and retired, validator addresses cannot be reused
-    /// @param emergencyExit When true, permanently forfeits accrued rewards and returns only the stake
-    /// balance; escape hatch for when the Issuance contract's balance cannot cover the rewards owed
+    /// @param emergencyExit When true, caps the rewards payout at the Issuance contract's available
+    /// balance and permanently forfeits only the shortfall, so an underfunded reward pool can never
+    /// block a stake withdrawal; identical to a normal unstake whenever Issuance can cover the rewards
     function unstake(address validatorAddress, bool emergencyExit) external;
 
     /// @notice Returns the delegation digest that a validator should sign to accept a delegation

--- a/src/interfaces/IStakeManager.sol
+++ b/src/interfaces/IStakeManager.sol
@@ -129,7 +129,9 @@ interface IStakeManager {
     /// @dev Returns previously staked funds in addition to accrued rewards, if any, to the staker
     /// @notice May be used to reverse validator onboarding pre-activation or permanently retire after full exit
     /// @notice Once unstaked and retired, validator addresses cannot be reused
-    function unstake(address validatorAddress) external;
+    /// @param emergencyExit When true, permanently forfeits accrued rewards and returns only the stake
+    /// balance; escape hatch for when the Issuance contract's balance cannot cover the rewards owed
+    function unstake(address validatorAddress, bool emergencyExit) external;
 
     /// @notice Returns the delegation digest that a validator should sign to accept a delegation
     /// @return _ EIP-712 typed struct hash used to enable delegated proof of stake

--- a/src/interfaces/IStakeManager.sol
+++ b/src/interfaces/IStakeManager.sol
@@ -129,10 +129,10 @@ interface IStakeManager {
     /// @dev Returns previously staked funds in addition to accrued rewards, if any, to the staker
     /// @notice May be used to reverse validator onboarding pre-activation or permanently retire after full exit
     /// @notice Once unstaked and retired, validator addresses cannot be reused
-    /// @param emergencyExit When true, caps the rewards payout at the Issuance contract's available
+    /// @param acceptRewardShortfall When true, caps the rewards payout at the Issuance contract's available
     /// balance and permanently forfeits only the shortfall, so an underfunded reward pool can never
     /// block a stake withdrawal; identical to a normal unstake whenever Issuance can cover the rewards
-    function unstake(address validatorAddress, bool emergencyExit) external;
+    function unstake(address validatorAddress, bool acceptRewardShortfall) external;
 
     /// @notice Returns the delegation digest that a validator should sign to accept a delegation
     /// @return _ EIP-712 typed struct hash used to enable delegated proof of stake

--- a/test/consensus/ConsensusRegistryTest.t.sol
+++ b/test/consensus/ConsensusRegistryTest.t.sol
@@ -9,6 +9,7 @@ import { SystemCallable } from "src/consensus/SystemCallable.sol";
 import { StakeManager } from "src/consensus/StakeManager.sol";
 import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
 import { RewardInfo, Slash, IStakeManager } from "src/interfaces/IStakeManager.sol";
+import { Issuance } from "src/consensus/Issuance.sol";
 import { ConsensusRegistryTestUtils } from "./ConsensusRegistryTestUtils.sol";
 
 contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
@@ -617,7 +618,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         vm.expectEmit(true, true, true, true);
         emit RewardsClaimed(validator1, stakeAmount_);
         vm.prank(validator1);
-        consensusRegistry.unstake(validator1);
+        consensusRegistry.unstake(validator1, false);
 
         // validator1 earned 4 epochs' rewards, split between 4 validators
         uint256 finalBalance = validator1.balance;
@@ -640,7 +641,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         // unstake to abort activation
         vm.expectEmit(true, true, true, true);
         emit RewardsClaimed(validator5, stakeAmount_);
-        consensusRegistry.unstake(validator5);
+        consensusRegistry.unstake(validator5, false);
 
         vm.stopPrank();
 
@@ -658,7 +659,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         vm.prank(nonValidator);
         vm.expectRevert();
-        consensusRegistry.unstake(nonValidator);
+        consensusRegistry.unstake(nonValidator, false);
     }
 
     // Test for unstake by a validator who has not exited
@@ -679,7 +680,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             ValidatorInfo(validator5, 1, 0, ValidatorStatus.PendingActivation, false, 0, 0)
         );
         vm.expectRevert(err);
-        consensusRegistry.unstake(validator5);
+        consensusRegistry.unstake(validator5, false);
 
         vm.stopPrank();
     }
@@ -1451,7 +1452,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         // --- delegator unstakes ---
         vm.deal(address(consensusRegistry), stakeAmount_);
         vm.prank(delegator);
-        consensusRegistry.unstake(validator5);
+        consensusRegistry.unstake(validator5, false);
 
         // delegation must be cleared
         assertFalse(consensusRegistry.isDelegated(validator5));
@@ -1483,5 +1484,91 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         // delegation must be cleared
         assertFalse(consensusRegistry.isDelegated(validator5));
+    }
+
+    /*
+     *   emergency exit
+     */
+
+    /// @dev Exits genesis `validator1` through the pending-exit queue and elapses one further
+    /// epoch so it becomes unstake-eligible
+    function _exitValidator1ToUnstakeEligibility() internal {
+        uint256 numActive = consensusRegistry.getEligibleValidatorCount();
+
+        vm.prank(validator1);
+        consensusRegistry.beginExit();
+
+        // validator1 serves in the genesis committees for the first epochs, so conclude past them
+        vm.startPrank(sysAddress);
+        address[] memory waitCommittee = _createTokenIdCommittee(numActive);
+        waitCommittee[waitCommittee.length - 1] = validator1;
+        consensusRegistry.concludeEpoch(waitCommittee);
+        address[] memory tokenIdCommittee = _createTokenIdCommittee(numActive);
+        consensusRegistry.concludeEpoch(tokenIdCommittee);
+        consensusRegistry.concludeEpoch(tokenIdCommittee);
+        vm.stopPrank();
+
+        uint256 activeAfterExit = numActive - 1;
+        vm.prank(crOwner);
+        consensusRegistry.setNextCommitteeSize(uint16(activeAfterExit));
+
+        // exit resolves on the next epoch conclusion; one further epoch reaches unstake eligibility
+        vm.startPrank(sysAddress);
+        address[] memory afterExitCommittee = _createTokenIdCommittee(activeAfterExit);
+        consensusRegistry.concludeEpoch(afterExitCommittee);
+        consensusRegistry.concludeEpoch(afterExitCommittee);
+        vm.stopPrank();
+    }
+
+    function test_unstake_emergencyExit_forfeitsRewards() public {
+        // validator1 accrues rewards
+        RewardInfo[] memory rewardInfos = new RewardInfo[](1);
+        rewardInfos[0] = RewardInfo(validator1, 10);
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(rewardInfos);
+        uint256 accrued = consensusRegistry.getRewards(validator1);
+        assertGt(accrued, 0);
+
+        _exitValidator1ToUnstakeEligibility();
+
+        uint256 issuanceBalBefore = issuance.balance;
+
+        // an emergency exit returns the stake but permanently forfeits the accrued rewards
+        vm.expectEmit(true, true, true, true);
+        emit RewardsClaimed(validator1, stakeAmount_);
+        vm.prank(validator1);
+        consensusRegistry.unstake(validator1, true);
+
+        assertEq(validator1.balance, stakeAmount_);
+        assertTrue(consensusRegistry.isRetired(validator1));
+        // the forfeited rewards remain in the Issuance reward pool
+        assertEq(issuance.balance, issuanceBalBefore);
+    }
+
+    function test_unstake_emergencyExit_insufficientIssuanceBalance() public {
+        // validator1 accrues rewards
+        RewardInfo[] memory rewardInfos = new RewardInfo[](1);
+        rewardInfos[0] = RewardInfo(validator1, 10);
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(rewardInfos);
+        uint256 accrued = consensusRegistry.getRewards(validator1);
+        assertGt(accrued, 0);
+
+        _exitValidator1ToUnstakeEligibility();
+
+        // empty the reward pool so accrued rewards can no longer be paid out
+        vm.deal(issuance, 0);
+
+        // a normal unstake cannot cover the rewards owed and reverts
+        vm.prank(validator1);
+        vm.expectRevert(
+            abi.encodeWithSelector(Issuance.InsufficientBalance.selector, stakeAmount_, stakeAmount_ + accrued)
+        );
+        consensusRegistry.unstake(validator1, false);
+
+        // the emergency exit path still returns the stake
+        vm.prank(validator1);
+        consensusRegistry.unstake(validator1, true);
+        assertEq(validator1.balance, stakeAmount_);
     }
 }

--- a/test/consensus/ConsensusRegistryTest.t.sol
+++ b/test/consensus/ConsensusRegistryTest.t.sol
@@ -1487,7 +1487,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
     }
 
     /*
-     *   emergency exit
+     *   reward-shortfall unstaking
      */
 
     /// @dev Exits genesis `validator1` through the pending-exit queue and elapses one further
@@ -1520,7 +1520,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         vm.stopPrank();
     }
 
-    function test_unstake_emergencyExit_paysFullRewardsWhenFunded() public {
+    function test_unstake_acceptRewardShortfall_paysFullRewardsWhenFunded() public {
         // validator1 accrues rewards
         RewardInfo[] memory rewardInfos = new RewardInfo[](1);
         rewardInfos[0] = RewardInfo(validator1, 10);
@@ -1533,7 +1533,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         uint256 issuanceBalBefore = issuance.balance;
 
-        // with a funded reward pool an emergency exit is identical to a normal unstake:
+        // with a funded reward pool a shortfall-accepting unstake is identical to a normal unstake:
         // nothing payable is ever forfeited
         vm.expectEmit(true, true, true, true);
         emit RewardsClaimed(validator1, stakeAmount_ + accrued);
@@ -1545,7 +1545,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         assertEq(issuance.balance, issuanceBalBefore - accrued);
     }
 
-    function test_unstake_emergencyExit_insufficientIssuanceBalance() public {
+    function test_unstake_acceptRewardShortfall_insufficientIssuanceBalance() public {
         // validator1 accrues rewards
         RewardInfo[] memory rewardInfos = new RewardInfo[](1);
         rewardInfos[0] = RewardInfo(validator1, 10);
@@ -1566,7 +1566,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         );
         consensusRegistry.unstake(validator1, false);
 
-        // the emergency exit path still returns the stake, forfeiting only the unpayable rewards
+        // the shortfall-accepting path still returns the stake, forfeiting only the unpayable rewards
         vm.expectEmit(true, true, true, true);
         emit RewardsClaimed(validator1, stakeAmount_);
         vm.prank(validator1);
@@ -1575,7 +1575,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         assertEq(issuance.balance, 0);
     }
 
-    function test_unstake_emergencyExit_partialShortfall() public {
+    function test_unstake_acceptRewardShortfall_partialShortfall() public {
         // validator1 accrues rewards
         RewardInfo[] memory rewardInfos = new RewardInfo[](1);
         rewardInfos[0] = RewardInfo(validator1, 10);
@@ -1599,7 +1599,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         );
         consensusRegistry.unstake(validator1, false);
 
-        // the emergency exit pays the stake plus the payable portion, forfeiting only the shortfall
+        // the shortfall-accepting path pays the stake plus the payable portion, forfeiting only the shortfall
         vm.expectEmit(true, true, true, true);
         emit RewardsClaimed(validator1, stakeAmount_ + payableRewards);
         vm.prank(validator1);

--- a/test/consensus/ConsensusRegistryTest.t.sol
+++ b/test/consensus/ConsensusRegistryTest.t.sol
@@ -1520,7 +1520,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         vm.stopPrank();
     }
 
-    function test_unstake_emergencyExit_forfeitsRewards() public {
+    function test_unstake_emergencyExit_paysFullRewardsWhenFunded() public {
         // validator1 accrues rewards
         RewardInfo[] memory rewardInfos = new RewardInfo[](1);
         rewardInfos[0] = RewardInfo(validator1, 10);
@@ -1533,16 +1533,16 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         uint256 issuanceBalBefore = issuance.balance;
 
-        // an emergency exit returns the stake but permanently forfeits the accrued rewards
+        // with a funded reward pool an emergency exit is identical to a normal unstake:
+        // nothing payable is ever forfeited
         vm.expectEmit(true, true, true, true);
-        emit RewardsClaimed(validator1, stakeAmount_);
+        emit RewardsClaimed(validator1, stakeAmount_ + accrued);
         vm.prank(validator1);
         consensusRegistry.unstake(validator1, true);
 
-        assertEq(validator1.balance, stakeAmount_);
+        assertEq(validator1.balance, stakeAmount_ + accrued);
         assertTrue(consensusRegistry.isRetired(validator1));
-        // the forfeited rewards remain in the Issuance reward pool
-        assertEq(issuance.balance, issuanceBalBefore);
+        assertEq(issuance.balance, issuanceBalBefore - accrued);
     }
 
     function test_unstake_emergencyExit_insufficientIssuanceBalance() public {
@@ -1566,9 +1566,47 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         );
         consensusRegistry.unstake(validator1, false);
 
-        // the emergency exit path still returns the stake
+        // the emergency exit path still returns the stake, forfeiting only the unpayable rewards
+        vm.expectEmit(true, true, true, true);
+        emit RewardsClaimed(validator1, stakeAmount_);
         vm.prank(validator1);
         consensusRegistry.unstake(validator1, true);
         assertEq(validator1.balance, stakeAmount_);
+        assertEq(issuance.balance, 0);
+    }
+
+    function test_unstake_emergencyExit_partialShortfall() public {
+        // validator1 accrues rewards
+        RewardInfo[] memory rewardInfos = new RewardInfo[](1);
+        rewardInfos[0] = RewardInfo(validator1, 10);
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(rewardInfos);
+        uint256 accrued = consensusRegistry.getRewards(validator1);
+        assertGt(accrued, 1);
+
+        _exitValidator1ToUnstakeEligibility();
+
+        // leave the reward pool able to cover only part of the accrued rewards
+        uint256 payableRewards = accrued / 2;
+        vm.deal(issuance, payableRewards);
+
+        // a normal unstake still reverts on the shortfall
+        vm.prank(validator1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Issuance.InsufficientBalance.selector, payableRewards + stakeAmount_, stakeAmount_ + accrued
+            )
+        );
+        consensusRegistry.unstake(validator1, false);
+
+        // the emergency exit pays the stake plus the payable portion, forfeiting only the shortfall
+        vm.expectEmit(true, true, true, true);
+        emit RewardsClaimed(validator1, stakeAmount_ + payableRewards);
+        vm.prank(validator1);
+        consensusRegistry.unstake(validator1, true);
+
+        assertEq(validator1.balance, stakeAmount_ + payableRewards);
+        assertEq(issuance.balance, 0);
+        assertTrue(consensusRegistry.isRetired(validator1));
     }
 }


### PR DESCRIPTION
## Finding

Cantina review, Medium. Reward underfunding can block principal unstaking.

`unstake` settles stake and accrued rewards in a single `Issuance.distributeStakeReward` call, which reverts `InsufficientBalance` whenever the Issuance contract's balance cannot cover `rewardAmount + msg.value`. The stake portion is forwarded as `msg.value` and is always fully backed by the registry, but the reward portion depends on the Issuance pool being sufficiently funded by governance allocations. An underfunded pool therefore blocks withdrawal of the principal too: a fully exited validator has no path to reclaim its stake until governance tops the pool back up.

## Fix

- `unstake(address validatorAddress, bool acceptRewardShortfall)`: when the flag is set, the rewards leg is capped at the Issuance contract's available balance, so principal withdrawal never depends on the reward pool's funding level.
  - With a funded pool the shortfall-accepting path is identical to a normal unstake: nothing payable is ever forfeited. This also keeps one party from burning the other's payable rewards on a delegated stake, since either the validator or its delegator may call `unstake`.
  - On a genuine shortfall the recipient receives the stake plus the payable portion of the rewards; only the unpayable remainder is forfeited. Funding-wise this path cannot fail.
- The capping happens in `_unstake` before the Issuance call, so `Issuance.distributeStakeReward` keeps its two-parameter signature.
- The normal path (`acceptRewardShortfall = false`) still reverts on underfunding, preserving the option to wait for a governance refill instead of forfeiting.
- The claim path and the version-change refund path are unchanged; the burn path requests shortfall semantics (inert there, since the balance ledger is already settled).

Note: this changes the `unstake` selector, so downstream callers and any off-chain bindings need the new boolean argument.

## Tests

- `test_unstake_acceptRewardShortfall_paysFullRewardsWhenFunded`: with a funded pool, the flag pays stake plus full rewards, identical to a normal unstake.
- `test_unstake_acceptRewardShortfall_insufficientIssuanceBalance`: with the reward pool emptied, a normal unstake reverts `InsufficientBalance` while the shortfall-accepting path still returns the stake, forfeiting only the unpayable rewards. Fails against the prior implementation, which had no way through.
- `test_unstake_acceptRewardShortfall_partialShortfall`: with the pool covering only part of the accrued rewards, a normal unstake still reverts while the shortfall-accepting path pays the stake plus the payable portion and drains the pool to zero.
- Existing unstake call sites updated to the two-argument form.

Full suite: 221 passed, 0 failed, 2 skipped.

Closes #144.
