### PR TITLE
feat(consensus): slashed-stake top-ups, governance issuance withdrawal, balance-capped incentives

### DIFF
--- a/src/consensus/ConsensusRegistry.sol
+++ b/src/consensus/ConsensusRegistry.sol
@@ -51,6 +51,10 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
     /// than three set-length reads. Invariant-tested against the eligible set sizes.
     uint256 internal eligibleValidatorCount;
 
+    /// @notice When true, `topUpSlashedStake` is restricted to governance; when false, validators
+    /// and their delegators may also restore their own slashed stake
+    bool public topUpAuthorityRequired;
+
     /// @dev Signals a validator's pending status until activation/exit to correctly apply incentives
     uint32 internal constant PENDING_EPOCH = type(uint32).max;
 
@@ -101,8 +105,12 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
             if (isRetired(reward.validatorAddress)) continue;
 
             uint8 rewardeeVersion = validators[reward.validatorAddress].stakeVersion;
-            // derive validator's weight using initial stake for stability
-            uint256 stakeAmount = versions[rewardeeVersion].stakeAmount;
+            // derive validator's weight from its effective stake: the version's full stake amount,
+            // capped to the outstanding balance when slashes have reduced it below that amount
+            // (restorable via `topUpSlashedStake`). Rewards above the stake amount never add weight
+            uint256 versionStakeAmount = versions[rewardeeVersion].stakeAmount;
+            uint256 balance = balances[reward.validatorAddress];
+            uint256 stakeAmount = balance < versionStakeAmount ? balance : versionStakeAmount;
             uint256 weight = stakeAmount * reward.consensusHeaderCount;
 
             totalWeight += weight;
@@ -464,6 +472,51 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
     }
 
     /// @inheritdoc IConsensusRegistry
+    function topUpSlashedStake(address validatorAddress) external payable override whenNotPaused {
+        // require `validatorAddress` is known & whitelisted, having been issued a ConsensusNFT by governance
+        _checkConsensusNFTOwner(validatorAddress);
+
+        // governance may always top up; other callers must be the validator or its delegator,
+        // and only while self-service top-ups are enabled
+        if (msg.sender != owner()) {
+            if (topUpAuthorityRequired) revert TopUpAuthorityRequired();
+            address recipient = _getRecipient(validatorAddress);
+            if (msg.sender != validatorAddress && msg.sender != recipient) revert NotRecipient(recipient);
+        }
+
+        // require validator status is `Staked`, `PendingActivation`, or `Active`
+        ValidatorStatus status = validators[validatorAddress].currentStatus;
+        if (
+            status != ValidatorStatus.Staked && status != ValidatorStatus.PendingActivation
+                && status != ValidatorStatus.Active
+        ) {
+            revert InvalidStatus(status);
+        }
+
+        uint8 validatorVersion = validators[validatorAddress].stakeVersion;
+        uint256 stakeAmount = versions[validatorVersion].stakeAmount;
+        uint256 currentBalance = balances[validatorAddress];
+        if (currentBalance >= stakeAmount) {
+            revert StakeNotSlashed(validatorAddress, currentBalance, validatorVersion);
+        }
+
+        uint256 deficit = stakeAmount - currentBalance;
+        if (msg.value != deficit) {
+            revert InvalidDeficitAmount(validatorAddress, msg.value, validatorVersion);
+        }
+
+        balances[validatorAddress] += deficit;
+        // this contract already holds the full stake-backed native TEL for a slashed validator
+        // (slashes decrement only the balance ledger), so the top-up value is consolidated on
+        // Issuance where it is repurposed for future reward distribution
+        (bool r,) = issuance.call{ value: msg.value }("");
+        // this is believed to be impossible
+        if (!r) revert IssuanceTransferFailed();
+
+        emit ValidatorStakeToppedUp(validatorAddress, deficit);
+    }
+
+    /// @inheritdoc IConsensusRegistry
     function activate() external override whenNotPaused {
         // require caller is whitelisted, having been issued a ConsensusNFT by governance
         _checkConsensusNFTOwner(msg.sender);
@@ -654,6 +707,17 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         (bool r,) = issuance.call{ value: msg.value }("");
         // this is believed to be impossible
         if (!r) revert IssuanceTransferFailed();
+    }
+
+    /// @inheritdoc StakeManager
+    function issuanceWithdrawal(uint256 amount) external override onlyOwner {
+        Issuance(issuance).withdraw(amount, msg.sender);
+    }
+
+    /// @inheritdoc IConsensusRegistry
+    function setTopUpAuthorityRequired(bool required) external override onlyOwner {
+        topUpAuthorityRequired = required;
+        emit TopUpAuthorityRequirementUpdated(required);
     }
 
     /**

--- a/src/consensus/Issuance.sol
+++ b/src/consensus/Issuance.sol
@@ -35,8 +35,19 @@ contract Issuance {
         if (!res) revert RewardDistributionFailure(recipient);
     }
 
-    /// @notice Received TEL cannot be recovered; it is effectively burned cryptographically
-    /// The only way received TEL can be re-minted is as staking issuance rewards
-    /// @notice Only governance may burn TEL in this manner
+    /// @notice Sends `amount` of this contract's TEL balance to `recipient`
+    /// @dev May only be called by StakeManager, which restricts the call to its governance owner
+    function withdraw(uint256 amount, address recipient) external onlyStakeManager {
+        uint256 bal = address(this).balance;
+        if (bal < amount) {
+            revert InsufficientBalance(bal, amount);
+        }
+
+        (bool res,) = recipient.call{ value: amount }("");
+        if (!res) revert RewardDistributionFailure(recipient);
+    }
+
+    /// @notice Received TEL leaves this contract only as staking issuance rewards or
+    /// through a governance withdrawal via the StakeManager
     receive() external payable onlyStakeManager { }
 }

--- a/src/consensus/StakeManager.sol
+++ b/src/consensus/StakeManager.sol
@@ -89,6 +89,9 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
     /// @inheritdoc IStakeManager
     function allocateIssuance() external payable virtual override;
 
+    /// @inheritdoc IStakeManager
+    function issuanceWithdrawal(uint256 amount) external virtual override;
+
     /**
      *
      *   ERC721

--- a/src/interfaces/IConsensusRegistry.sol
+++ b/src/interfaces/IConsensusRegistry.sol
@@ -83,6 +83,20 @@ interface IConsensusRegistry {
     /// @param validator The full ValidatorInfo of the ineligible validator
     error IneligibleUnstake(ValidatorInfo validator);
 
+    /// @notice Thrown on top-up attempts for a validator whose balance is not below its stake amount
+    /// @param validatorAddress The validator that is not slashed
+    /// @param balance The validator's current outstanding balance
+    /// @param stakeVersion The validator's stake version defining the required stake amount
+    error StakeNotSlashed(address validatorAddress, uint256 balance, uint8 stakeVersion);
+    /// @notice Thrown when a top-up is attempted by a non-governance caller while top-ups
+    /// are restricted to the governance top-up authority
+    error TopUpAuthorityRequired();
+    /// @notice Thrown when a top-up's `msg.value` does not exactly match the validator's stake deficit
+    /// @param validatorAddress The validator being topped up
+    /// @param value The `msg.value` that was provided
+    /// @param stakeVersion The validator's stake version defining the required stake amount
+    error InvalidDeficitAmount(address validatorAddress, uint256 value, uint8 stakeVersion);
+
     /// @notice Emitted when a validator first stakes, entering the Staked lifecycle state
     /// @param validator The newly staked validator's info
     event ValidatorStaked(ValidatorInfo validator);
@@ -141,6 +155,15 @@ interface IConsensusRegistry {
     /// in-place upgrade from a deployment that predates them
     /// @param eligibleValidatorCount The committee-eligible count after the back-fill
     event ValidatorSetsMigrated(uint256 eligibleValidatorCount);
+
+    /// @notice Emitted when governance toggles whether `topUpSlashedStake` is restricted to
+    /// the governance top-up authority
+    /// @param required The new value of the `topUpAuthorityRequired` flag
+    event TopUpAuthorityRequirementUpdated(bool required);
+    /// @notice Emitted when a slashed validator's balance is restored to its version's full stake amount
+    /// @param validatorAddress The validator whose stake was topped up
+    /// @param amount The deficit that was provided and consolidated on the Issuance contract
+    event ValidatorStakeToppedUp(address indexed validatorAddress, uint256 amount);
 
     /// @dev Validators marked `Active || PendingActivation || PendingExit` are still operational
     /// and thus eligible for committees. Queriable via `getValidators(Active)` status
@@ -251,4 +274,16 @@ interface IConsensusRegistry {
     /// @notice After retiring, a validator's `tokenId == validatorAddress` cannot be reused
     function isRetired(address validatorAddress) external view returns (bool);
 
+    /// @notice Restores a slashed validator's balance to its version's full stake amount
+    /// @dev `msg.value` must equal the exact deficit; it is consolidated on the Issuance contract
+    /// since this contract retains the full stake-backed native TEL when slashes are applied
+    /// @dev Callable by governance at any time; by the validator or its delegator only while
+    /// `topUpAuthorityRequired` is false
+    /// @param validatorAddress The slashed validator to top up; must be `Staked`,
+    /// `PendingActivation`, or `Active`
+    function topUpSlashedStake(address validatorAddress) external payable;
+
+    /// @notice Toggles whether `topUpSlashedStake` is restricted to the governance top-up authority
+    /// @dev Only callable by governance (owner)
+    function setTopUpAuthorityRequired(bool required) external;
 }

--- a/src/interfaces/IStakeManager.sol
+++ b/src/interfaces/IStakeManager.sol
@@ -166,9 +166,9 @@ interface IStakeManager {
     function upgradeStakeVersion(StakeConfig calldata newVersion) external returns (uint8);
 
     /// @dev Permissioned function to allocate TEL for epoch issuance, ie consensus block rewards
-    /// @notice Allocated TEL cannot be recovered; it is effectively burned cryptographically
-    /// The only way received TEL can be re-minted is as staking issuance rewards
-    /// @notice Only governance may burn TEL in this manner
+    /// @notice Allocated TEL leaves the Issuance contract only as staking issuance rewards or
+    /// through a governance withdrawal via `issuanceWithdrawal`
+    /// @notice Only governance may allocate TEL in this manner
     function allocateIssuance() external payable;
 
     /// @dev Allows a staked validator (or its delegator) to upgrade their stake version in-place.
@@ -183,4 +183,10 @@ interface IStakeManager {
     /// The recipient still receives the correct total ETH via the refund. Validators should claim
     /// rewards before upgrading if they have both accrued rewards and pending slashes.
     function upgradeValidatorStakeVersion(address validatorAddress, uint8 targetVersion) external payable;
+
+    /// @dev Permissioned function to withdraw TEL from the Issuance contract to the caller
+    /// @notice Only governance may withdraw in this manner, eg to recover consolidated slash
+    /// funds or to reduce a prior issuance allocation
+    /// @param amount The amount of TEL to withdraw from the Issuance contract
+    function issuanceWithdrawal(uint256 amount) external;
 }

--- a/test/consensus/ConsensusRegistryTest.t.sol
+++ b/test/consensus/ConsensusRegistryTest.t.sol
@@ -9,6 +9,7 @@ import { SystemCallable } from "src/consensus/SystemCallable.sol";
 import { StakeManager } from "src/consensus/StakeManager.sol";
 import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
 import { RewardInfo, Slash, IStakeManager } from "src/interfaces/IStakeManager.sol";
+import { Issuance } from "src/consensus/Issuance.sol";
 import { ConsensusRegistryTestUtils } from "./ConsensusRegistryTestUtils.sol";
 
 contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
@@ -1170,7 +1171,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator1);
         assertEq(balAfter, newStakeAmt);
 
-        // getRewards() = 0 (rewards zeroed — this is expected/documented behavior)
+        // getRewards() = 0 (rewards zeroed - this is expected/documented behavior)
         // After version change, rewards = balance - newStakeAmount = 600k - 600k = 0
         uint256 rewardsAfter = consensusRegistry.getRewards(validator1);
         assertEq(rewardsAfter, 0);
@@ -1324,7 +1325,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         vm.prank(crOwner);
         consensusRegistry.pause();
 
-        // Try upgrade — expect revert with EnforcedPause
+        // Try upgrade - expect revert with EnforcedPause
         vm.prank(validator1);
         vm.expectRevert(Pausable.EnforcedPause.selector);
         consensusRegistry.upgradeValidatorStakeVersion(validator1, newVersion);
@@ -1483,5 +1484,319 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         // delegation must be cleared
         assertFalse(consensusRegistry.isDelegated(validator5));
+    }
+
+    /*
+     *   slashed-stake top-ups
+     */
+
+    /// @dev Partially slashes genesis `validator1` via system call
+    function _slashValidator1(uint256 amount) internal {
+        Slash[] memory slashes = new Slash[](1);
+        slashes[0] = Slash(validator1, amount);
+        vm.prank(sysAddress);
+        consensusRegistry.applySlashes(slashes);
+    }
+
+    /// @dev Exits genesis `validator1` through the pending-exit queue and elapses one further
+    /// epoch so it becomes unstake-eligible
+    function _exitValidator1ToUnstakeEligibility() internal {
+        uint256 numActive = consensusRegistry.getEligibleValidatorCount();
+
+        vm.prank(validator1);
+        consensusRegistry.beginExit();
+
+        // validator1 serves in the genesis committees for the first epochs, so conclude past them
+        vm.startPrank(sysAddress);
+        address[] memory waitCommittee = _createTokenIdCommittee(numActive);
+        waitCommittee[waitCommittee.length - 1] = validator1;
+        consensusRegistry.concludeEpoch(waitCommittee);
+        address[] memory tokenIdCommittee = _createTokenIdCommittee(numActive);
+        consensusRegistry.concludeEpoch(tokenIdCommittee);
+        consensusRegistry.concludeEpoch(tokenIdCommittee);
+        vm.stopPrank();
+
+        uint256 activeAfterExit = numActive - 1;
+        vm.prank(crOwner);
+        consensusRegistry.setNextCommitteeSize(uint16(activeAfterExit));
+
+        // exit resolves on the next epoch conclusion; one further epoch reaches unstake eligibility
+        vm.startPrank(sysAddress);
+        address[] memory afterExitCommittee = _createTokenIdCommittee(activeAfterExit);
+        consensusRegistry.concludeEpoch(afterExitCommittee);
+        consensusRegistry.concludeEpoch(afterExitCommittee);
+        vm.stopPrank();
+    }
+
+    function test_applyIncentives_slashedValidatorWeightReduced() public {
+        // slash validator1 to half its stake; equal header counts should now yield unequal rewards
+        uint256 slashAmt = stakeAmount_ / 2;
+        _slashValidator1(slashAmt);
+
+        RewardInfo[] memory rewardInfos = new RewardInfo[](2);
+        rewardInfos[0] = RewardInfo(validator1, 10);
+        rewardInfos[1] = RewardInfo(validator2, 10);
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(rewardInfos);
+
+        // validator1's weight derives from its reduced balance, validator2's from its full stake
+        uint256 slashedWeight = (stakeAmount_ - slashAmt) * 10;
+        uint256 fullWeight = stakeAmount_ * 10;
+        uint256 totalWeight = slashedWeight + fullWeight;
+        uint256 expected1 = epochIssuance_ * slashedWeight / totalWeight;
+        uint256 expected2 = epochIssuance_ * fullWeight / totalWeight;
+
+        (uint256 bal1,,) = consensusRegistry.getBalanceBreakdown(validator1);
+        (uint256 bal2,,) = consensusRegistry.getBalanceBreakdown(validator2);
+        assertEq(bal1, stakeAmount_ - slashAmt + expected1);
+        assertEq(bal2, stakeAmount_ + expected2);
+        assertEq(consensusRegistry.getRewards(validator2), expected2);
+    }
+
+    function test_applyIncentives_rewardsDoNotIncreaseWeight() public {
+        // validator1 accrues rewards, pushing its balance above the stake amount
+        RewardInfo[] memory firstRound = new RewardInfo[](1);
+        firstRound[0] = RewardInfo(validator1, 10);
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(firstRound);
+        uint256 firstRoundRewards = consensusRegistry.getRewards(validator1);
+        assertEq(firstRoundRewards, epochIssuance_);
+
+        // second round: equal header counts for validator1 and validator2 yield equal rewards
+        // because weight is capped at the version's stake amount
+        RewardInfo[] memory secondRound = new RewardInfo[](2);
+        secondRound[0] = RewardInfo(validator1, 10);
+        secondRound[1] = RewardInfo(validator2, 10);
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(secondRound);
+
+        assertEq(consensusRegistry.getRewards(validator1), firstRoundRewards + epochIssuance_ / 2);
+        assertEq(consensusRegistry.getRewards(validator2), epochIssuance_ / 2);
+    }
+
+    function test_topUpSlashedStake_validatorSelf() public {
+        uint256 slashAmt = 200_000e18;
+        _slashValidator1(slashAmt);
+
+        uint256 registryBalBefore = address(consensusRegistry).balance;
+        uint256 issuanceBalBefore = issuance.balance;
+
+        vm.deal(validator1, slashAmt);
+        vm.expectEmit(true, true, true, true);
+        emit ValidatorStakeToppedUp(validator1, slashAmt);
+        vm.prank(validator1);
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+
+        // the balance ledger is restored to the full stake amount
+        (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator1);
+        assertEq(balAfter, stakeAmount_);
+
+        // the top-up value consolidates on Issuance; the registry retains its stake-backed native
+        assertEq(issuance.balance, issuanceBalBefore + slashAmt);
+        assertEq(address(consensusRegistry).balance, registryBalBefore);
+    }
+
+    function test_topUpSlashedStake_ownerWhenAuthorityRequired() public {
+        uint256 slashAmt = 150_000e18;
+        _slashValidator1(slashAmt);
+
+        vm.prank(crOwner);
+        consensusRegistry.setTopUpAuthorityRequired(true);
+
+        vm.deal(crOwner, slashAmt);
+        vm.prank(crOwner);
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+
+        (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator1);
+        assertEq(balAfter, stakeAmount_);
+    }
+
+    function test_topUpSlashedStake_delegator() public {
+        // setup delegation for validator5
+        uint256 validator5PrivateKey = 5;
+        validator5 = vm.addr(validator5PrivateKey);
+        address delegator = _addressFromPrivateKey(42);
+        vm.deal(delegator, stakeAmount_);
+
+        vm.prank(crOwner);
+        consensusRegistry.mint(validator5);
+
+        bytes32 structHash = consensusRegistry.delegationDigest(validator5BlsPubkey, validator5, delegator);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(validator5PrivateKey, structHash);
+        bytes memory validatorSig = abi.encodePacked(r, s, v);
+
+        vm.prank(delegator);
+        consensusRegistry.delegateStake{ value: stakeAmount_ }(
+            validator5BlsPubkey, IStakeManager.ProofOfPossession(validator5BlsSig), validator5, validatorSig
+        );
+
+        // slash the staked validator5, then its delegator restores the stake
+        uint256 slashAmt = 100_000e18;
+        Slash[] memory slashes = new Slash[](1);
+        slashes[0] = Slash(validator5, slashAmt);
+        vm.prank(sysAddress);
+        consensusRegistry.applySlashes(slashes);
+
+        vm.deal(delegator, slashAmt);
+        vm.prank(delegator);
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator5);
+
+        (uint256 balAfter,,) = consensusRegistry.getBalanceBreakdown(validator5);
+        assertEq(balAfter, stakeAmount_);
+    }
+
+    function test_topUpSlashedStake_thenUnstake_noOrphanedFunds() public {
+        uint256 slashAmt = 200_000e18;
+        _slashValidator1(slashAmt);
+
+        // top up, restoring the ledger; the deficit consolidates on Issuance
+        vm.deal(validator1, slashAmt);
+        vm.prank(validator1);
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+
+        _exitValidator1ToUnstakeEligibility();
+
+        uint256 registryBalBefore = address(consensusRegistry).balance;
+        uint256 issuanceBalBefore = issuance.balance;
+
+        vm.prank(validator1);
+        consensusRegistry.unstake(validator1);
+
+        // the full stake returns and no native TEL is left stranded on the registry
+        assertEq(validator1.balance, stakeAmount_);
+        assertEq(address(consensusRegistry).balance, registryBalBefore - stakeAmount_);
+        assertEq(issuance.balance, issuanceBalBefore);
+    }
+
+    function testRevert_topUpSlashedStake_authorityRequired() public {
+        uint256 slashAmt = 100_000e18;
+        _slashValidator1(slashAmt);
+
+        vm.prank(crOwner);
+        consensusRegistry.setTopUpAuthorityRequired(true);
+
+        vm.deal(validator1, slashAmt);
+        vm.prank(validator1);
+        vm.expectRevert(TopUpAuthorityRequired.selector);
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+    }
+
+    function testRevert_topUpSlashedStake_notRecipient() public {
+        uint256 slashAmt = 100_000e18;
+        _slashValidator1(slashAmt);
+
+        address thirdParty = address(0xbeef);
+        vm.deal(thirdParty, slashAmt);
+        vm.prank(thirdParty);
+        vm.expectRevert(abi.encodeWithSelector(IStakeManager.NotRecipient.selector, validator1));
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+    }
+
+    function testRevert_topUpSlashedStake_notSlashed() public {
+        vm.deal(validator1, 1);
+        vm.prank(validator1);
+        vm.expectRevert(abi.encodeWithSelector(StakeNotSlashed.selector, validator1, stakeAmount_, uint8(0)));
+        consensusRegistry.topUpSlashedStake{ value: 1 }(validator1);
+    }
+
+    function testRevert_topUpSlashedStake_wrongValue() public {
+        uint256 slashAmt = 100_000e18;
+        _slashValidator1(slashAmt);
+
+        uint256 wrongValue = slashAmt - 1;
+        vm.deal(validator1, wrongValue);
+        vm.prank(validator1);
+        vm.expectRevert(abi.encodeWithSelector(InvalidDeficitAmount.selector, validator1, wrongValue, uint8(0)));
+        consensusRegistry.topUpSlashedStake{ value: wrongValue }(validator1);
+    }
+
+    function testRevert_topUpSlashedStake_invalidStatus() public {
+        uint256 slashAmt = 100_000e18;
+        _slashValidator1(slashAmt);
+
+        // pending-exit validators may not top up
+        vm.prank(validator1);
+        consensusRegistry.beginExit();
+
+        vm.deal(validator1, slashAmt);
+        vm.prank(validator1);
+        vm.expectRevert(abi.encodeWithSelector(InvalidStatus.selector, ValidatorStatus.PendingExit));
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+    }
+
+    function testRevert_topUpSlashedStake_unknownValidator() public {
+        address unknown = address(0xabc);
+        vm.deal(unknown, 1 ether);
+        vm.prank(unknown);
+        vm.expectRevert(abi.encodeWithSelector(IStakeManager.InvalidTokenId.selector, _getTokenId(unknown)));
+        consensusRegistry.topUpSlashedStake{ value: 1 ether }(unknown);
+    }
+
+    function testRevert_topUpSlashedStake_paused() public {
+        uint256 slashAmt = 100_000e18;
+        _slashValidator1(slashAmt);
+
+        vm.prank(crOwner);
+        consensusRegistry.pause();
+
+        vm.deal(validator1, slashAmt);
+        vm.prank(validator1);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        consensusRegistry.topUpSlashedStake{ value: slashAmt }(validator1);
+    }
+
+    function test_setTopUpAuthorityRequired() public {
+        assertFalse(consensusRegistry.topUpAuthorityRequired());
+
+        vm.expectEmit(true, true, true, true);
+        emit TopUpAuthorityRequirementUpdated(true);
+        vm.prank(crOwner);
+        consensusRegistry.setTopUpAuthorityRequired(true);
+        assertTrue(consensusRegistry.topUpAuthorityRequired());
+
+        vm.prank(crOwner);
+        consensusRegistry.setTopUpAuthorityRequired(false);
+        assertFalse(consensusRegistry.topUpAuthorityRequired());
+    }
+
+    function testRevert_setTopUpAuthorityRequired_notOwner() public {
+        vm.prank(validator1);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUnauthorizedAccount.selector, validator1));
+        consensusRegistry.setTopUpAuthorityRequired(true);
+    }
+
+    /*
+     *   issuanceWithdrawal
+     */
+
+    function test_issuanceWithdrawal() public {
+        uint256 amount = 10_000e18;
+        uint256 issuanceBalBefore = issuance.balance;
+        uint256 ownerBalBefore = crOwner.balance;
+
+        vm.prank(crOwner);
+        consensusRegistry.issuanceWithdrawal(amount);
+
+        assertEq(issuance.balance, issuanceBalBefore - amount);
+        assertEq(crOwner.balance, ownerBalBefore + amount);
+    }
+
+    function testRevert_issuanceWithdrawal_notOwner() public {
+        vm.prank(validator1);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUnauthorizedAccount.selector, validator1));
+        consensusRegistry.issuanceWithdrawal(1);
+    }
+
+    function testRevert_issuanceWithdrawal_insufficientBalance() public {
+        uint256 available = issuance.balance;
+        vm.prank(crOwner);
+        vm.expectRevert(abi.encodeWithSelector(Issuance.InsufficientBalance.selector, available, available + 1));
+        consensusRegistry.issuanceWithdrawal(available + 1);
+    }
+
+    function testRevert_issuanceWithdraw_onlyStakeManager() public {
+        vm.prank(crOwner);
+        vm.expectRevert(abi.encodeWithSelector(Issuance.OnlyStakeManager.selector, address(consensusRegistry)));
+        Issuance(issuance).withdraw(1, crOwner);
     }
 }


### PR DESCRIPTION
## Changes

Three related stake-administration features. None of these carries a Medium audit finding; the Medium fixes formerly bundled alongside them (burn stranding, emergency exit) are split into their own PRs.

### Slashed-stake top-ups (`topUpSlashedStake` + `setTopUpAuthorityRequired`)

Slashes decrement only the balance ledger, so a slashed validator's collateral can be restored without unstaking. `topUpSlashedStake` accepts the exact deficit as `msg.value`, credits the ledger back to the version's full stake amount, and consolidates the value on the Issuance contract (the registry already holds the full stake-backed native TEL).

- Governance may always top up. Validators and their delegators may self-serve while the new `topUpAuthorityRequired` flag is false; setting it true (via `setTopUpAuthorityRequired`, owner-only) restricts top-ups to governance. Third parties can never top up.
- Only `Staked`, `PendingActivation`, or `Active` validators qualify; the top-up requires an actual deficit (`StakeNotSlashed` otherwise) and an exact `msg.value` (`InvalidDeficitAmount`).
- New `ValidatorStakeToppedUp` and `TopUpAuthorityRequirementUpdated` events.
- Storage: `topUpAuthorityRequired` is a layout-safe append after `eligibleValidatorCount`.

### Governance issuance withdrawal (`issuanceWithdrawal`)

Adds an owner-only path to withdraw native TEL from the Issuance contract through the registry (`Issuance.withdraw` is gated to the StakeManager). This enables recovering consolidated slash funds or reducing a prior over-allocation; the stale "allocated TEL cannot be recovered" natspec is updated accordingly.

### Balance-capped incentive weights (`applyIncentives`)

Reward weight now derives from the validator's effective stake: the version's stake amount, capped to the outstanding balance when slashes have reduced it below that amount. A slashed validator earns proportionally less until it tops up or is made whole; accrued rewards above the stake amount still never add weight.

## Tests

- Top-ups: self-service, governance under the flag, delegator, and a top-up-then-unstake round trip asserting no native TEL is stranded; reverts for restricted authority, third-party callers, non-slashed balances, wrong `msg.value`, `PendingExit` status, unknown validators, and paused state.
- `setTopUpAuthorityRequired`: toggle behavior + event, non-owner revert.
- `issuanceWithdrawal`: happy path, non-owner revert, insufficient balance, and the direct-call `OnlyStakeManager` gate on `Issuance.withdraw`.
- `applyIncentives`: slashed validators earn reduced weight; reward accrual above the stake amount does not increase weight.

Full suite: 237 passed, 0 failed, 2 skipped.