### PR TITLE
fix(consensus): project future epoch info from the latest stake config; clarify version getter semantics

### DIFF
--- a/src/consensus/ConsensusRegistry.sol
+++ b/src/consensus/ConsensusRegistry.sol
@@ -518,9 +518,11 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
             revert InvalidStatus(status);
         }
 
-        // 3. Version validation: must be strictly newer, within bounds
+        // 3. Version validation: must be strictly newer and already epoch-active. New configs
+        // take effect at the next epoch boundary, so a version that has not yet been stamped
+        // into an epoch by `concludeEpoch` cannot be adopted early
         uint8 oldVersion = validator.stakeVersion;
-        if (targetVersion <= oldVersion || targetVersion > stakeVersion) {
+        if (targetVersion <= oldVersion || targetVersion > getCurrentStakeVersion()) {
             revert InvalidStakeVersion(oldVersion, targetVersion);
         }
 
@@ -981,7 +983,10 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         epochPointer = newEpochPointer;
         uint32 newEpoch = ++currentEpoch;
         address[] storage newCommittee = futureEpochInfo[newEpochPointer].committee;
-        StakeConfig memory newStakeConfig = getCurrentStakeConfig();
+        // read the latest stake config directly: it is what the incoming epoch is stamped with.
+        // The epoch-based `getCurrentStakeConfig` cannot be used mid-transition because the
+        // incoming epoch's `epochInfo` slot is only written below
+        StakeConfig memory newStakeConfig = versions[stakeVersion];
         epochInfo[newEpochPointer] = EpochInfo(
             newCommittee,
             newStakeConfig.epochIssuance,
@@ -991,16 +996,18 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
             stakeVersion
         );
 
-        // update future epoch info
+        // update future epoch info; only the committee and epoch id are knowable ahead of time,
+        // so the config fields and block height are explicitly zeroed. The epoch's actual config
+        // is stamped above when it begins, since governance may change it up until then
         uint8 twoEpochsInFuturePointer = (newEpochPointer + 2) % 4;
-        futureEpochInfo[twoEpochsInFuturePointer].committee = futureCommittee;
-        futureEpochInfo[twoEpochsInFuturePointer].epochId = newEpoch + 2;
+        futureEpochInfo[twoEpochsInFuturePointer] = EpochInfo(futureCommittee, 0, 0, newEpoch + 2, 0, 0);
 
         return (newEpoch, newStakeConfig.epochIssuance, newStakeConfig.epochDuration, newCommittee);
     }
 
     /// @dev Fetch info for a future epoch; two epochs into future are stored
-    /// @notice Block height is not known for future epochs, so it will be 0
+    /// @notice Only the committee and epoch id are known ahead of time; the config fields
+    /// (issuance, duration, stake version) and block height are zero until the epoch begins
     function _getFutureEpochInfo(
         uint32 future,
         uint32 current,
@@ -1164,17 +1171,16 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         // NOTE: committees are expected to always be < 100
         nextCommitteeSize = uint16(initialValidators_.length);
 
-        // set first three epochs with genesis config
+        // set first three epochs with genesis config; future epoch slots carry only the
+        // committee and epoch id, since a future epoch's configuration is undefined until
+        // it is stamped into `epochInfo` at that epoch's start
         for (uint256 j; j <= 2; ++j) {
             EpochInfo storage epoch = epochInfo[j];
             epoch.epochId = uint32(j);
             epoch.epochDuration = genesisConfig_.epochDuration;
             epoch.epochIssuance = genesisConfig_.epochIssuance;
 
-            EpochInfo storage futureEpoch = futureEpochInfo[j];
-            futureEpoch.epochId = uint32(j);
-            futureEpoch.epochDuration = genesisConfig_.epochDuration;
-            futureEpoch.epochIssuance = genesisConfig_.epochIssuance;
+            futureEpochInfo[j].epochId = uint32(j);
         }
 
         // set initial validators

--- a/src/consensus/ConsensusRegistry.sol
+++ b/src/consensus/ConsensusRegistry.sol
@@ -225,6 +225,8 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
 
     /// @inheritdoc IStakeManager
     function getCurrentStakeVersion() public view override returns (uint8) {
+        // the version stamped into the current epoch at its start; a version authored
+        // mid-epoch is reflected by `getCurrentStakeConfig` but not here until the next epoch
         return getCurrentEpochInfo().stakeVersion;
     }
 
@@ -247,7 +249,16 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
 
         uint8 currentPointer = epochPointer;
         if (epoch > current) {
-            return _getFutureEpochInfo(epoch, current, currentPointer);
+            // future slots store only the committee and epoch id; project the config fields
+            // from the latest authored configuration - the values the epoch would be stamped
+            // with if it began now. They can change until the epoch is stamped at its start.
+            // Block height is unknowable ahead of time and remains 0
+            EpochInfo memory future = _getFutureEpochInfo(epoch, current, currentPointer);
+            StakeConfig storage latestConfig = versions[stakeVersion];
+            future.epochIssuance = latestConfig.epochIssuance;
+            future.epochDuration = latestConfig.epochDuration;
+            future.stakeVersion = stakeVersion;
+            return future;
         } else {
             return _getRecentEpochInfo(epoch, current, currentPointer);
         }
@@ -518,11 +529,9 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
             revert InvalidStatus(status);
         }
 
-        // 3. Version validation: must be strictly newer and already epoch-active. New configs
-        // take effect at the next epoch boundary, so a version that has not yet been stamped
-        // into an epoch by `concludeEpoch` cannot be adopted early
+        // 3. Version validation: must be strictly newer, within bounds
         uint8 oldVersion = validator.stakeVersion;
-        if (targetVersion <= oldVersion || targetVersion > getCurrentStakeVersion()) {
+        if (targetVersion <= oldVersion || targetVersion > stakeVersion) {
             revert InvalidStakeVersion(oldVersion, targetVersion);
         }
 
@@ -983,10 +992,7 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
         epochPointer = newEpochPointer;
         uint32 newEpoch = ++currentEpoch;
         address[] storage newCommittee = futureEpochInfo[newEpochPointer].committee;
-        // read the latest stake config directly: it is what the incoming epoch is stamped with.
-        // The epoch-based `getCurrentStakeConfig` cannot be used mid-transition because the
-        // incoming epoch's `epochInfo` slot is only written below
-        StakeConfig memory newStakeConfig = versions[stakeVersion];
+        StakeConfig memory newStakeConfig = getCurrentStakeConfig();
         epochInfo[newEpochPointer] = EpochInfo(
             newCommittee,
             newStakeConfig.epochIssuance,
@@ -1006,8 +1012,8 @@ contract ConsensusRegistry is StakeManager, Pausable, Ownable, ReentrancyGuard, 
     }
 
     /// @dev Fetch info for a future epoch; two epochs into future are stored
-    /// @notice Only the committee and epoch id are known ahead of time; the config fields
-    /// (issuance, duration, stake version) and block height are zero until the epoch begins
+    /// @notice Storage carries only the committee and epoch id; the config fields and block
+    /// height are zero. `getEpochInfo` overlays a projection of the config fields at read time
     function _getFutureEpochInfo(
         uint32 future,
         uint32 current,

--- a/src/consensus/StakeManager.sol
+++ b/src/consensus/StakeManager.sol
@@ -71,18 +71,15 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
     function getBalanceBreakdown(address validatorAddress) public view virtual returns (uint256, uint256, uint256);
 
     /// @inheritdoc IStakeManager
-    function getCurrentStakeVersion() public view virtual returns (uint8);
-
-    /// @inheritdoc IStakeManager
     function stakeConfig(uint8 version) public view virtual returns (StakeConfig memory) {
         return versions[version];
     }
 
     /// @inheritdoc IStakeManager
     function getCurrentStakeConfig() public view returns (StakeConfig memory) {
-        // keyed on the epoch-active version so this getter always agrees with
-        // `getCurrentStakeVersion`; the latest `stakeVersion` may still be pending activation
-        return versions[getCurrentStakeVersion()];
+        // the latest authored configuration; it activates at the next epoch start, when
+        // `concludeEpoch` stamps it into the new epoch's info
+        return versions[stakeVersion];
     }
 
     /// @inheritdoc IStakeManager

--- a/src/consensus/StakeManager.sol
+++ b/src/consensus/StakeManager.sol
@@ -71,13 +71,18 @@ abstract contract StakeManager is ERC721Enumerable, EIP712, IStakeManager {
     function getBalanceBreakdown(address validatorAddress) public view virtual returns (uint256, uint256, uint256);
 
     /// @inheritdoc IStakeManager
+    function getCurrentStakeVersion() public view virtual returns (uint8);
+
+    /// @inheritdoc IStakeManager
     function stakeConfig(uint8 version) public view virtual returns (StakeConfig memory) {
         return versions[version];
     }
 
     /// @inheritdoc IStakeManager
     function getCurrentStakeConfig() public view returns (StakeConfig memory) {
-        return versions[stakeVersion];
+        // keyed on the epoch-active version so this getter always agrees with
+        // `getCurrentStakeVersion`; the latest `stakeVersion` may still be pending activation
+        return versions[getCurrentStakeVersion()];
     }
 
     /// @inheritdoc IStakeManager

--- a/src/interfaces/IConsensusRegistry.sol
+++ b/src/interfaces/IConsensusRegistry.sol
@@ -35,15 +35,15 @@ interface IConsensusRegistry {
     struct EpochInfo {
         /// @notice Ordered set of validator addresses selected for this epoch's voting committee
         address[] committee;
-        /// @notice Total TEL distributed as staking rewards during this epoch; 0 for future epochs
+        /// @notice Total TEL distributed as staking rewards during this epoch
         uint256 epochIssuance;
         /// @notice The L2 block number at which this epoch started; 0 for future epochs not yet begun
         uint64 blockHeight;
         /// @notice Sequential identifier for this epoch
         uint32 epochId;
-        /// @notice Duration of this epoch in L2 blocks; 0 for future epochs
+        /// @notice Duration of this epoch in L2 blocks
         uint32 epochDuration;
-        /// @notice The global StakeConfig version that was active when this epoch started; 0 for future epochs
+        /// @notice The global StakeConfig version that was active when this epoch started
         uint8 stakeVersion;
     }
 
@@ -211,7 +211,9 @@ interface IConsensusRegistry {
     function getCurrentEpochInfo() external view returns (EpochInfo memory);
 
     /// @dev Returns information about the provided epoch. Only four latest & two future epochs are stored
-    /// @notice When querying for future epochs, `blockHeight` will be 0 as they are not yet known
+    /// @notice For future epochs, the config fields (issuance, duration, stake version) are a
+    /// projection from the latest authored configuration and can change until the epoch is
+    /// stamped at its start; `blockHeight` is always 0 as it is not yet known
     function getEpochInfo(uint32 epoch) external view returns (EpochInfo memory);
 
     /// @dev Returns the addresses of validators in exactly the provided status's set, in the set's

--- a/src/interfaces/IConsensusRegistry.sol
+++ b/src/interfaces/IConsensusRegistry.sol
@@ -35,15 +35,15 @@ interface IConsensusRegistry {
     struct EpochInfo {
         /// @notice Ordered set of validator addresses selected for this epoch's voting committee
         address[] committee;
-        /// @notice Total TEL distributed as staking rewards during this epoch
+        /// @notice Total TEL distributed as staking rewards during this epoch; 0 for future epochs
         uint256 epochIssuance;
         /// @notice The L2 block number at which this epoch started; 0 for future epochs not yet begun
         uint64 blockHeight;
         /// @notice Sequential identifier for this epoch
         uint32 epochId;
-        /// @notice Duration of this epoch in L2 blocks
+        /// @notice Duration of this epoch in L2 blocks; 0 for future epochs
         uint32 epochDuration;
-        /// @notice The global StakeConfig version that was active when this epoch started
+        /// @notice The global StakeConfig version that was active when this epoch started; 0 for future epochs
         uint8 stakeVersion;
     }
 

--- a/src/interfaces/IStakeManager.sol
+++ b/src/interfaces/IStakeManager.sol
@@ -85,7 +85,7 @@ interface IStakeManager {
     /// @notice Thrown when unstaking would reduce ConsensusNFT totalSupply to zero
     error InvalidSupply();
     /// @notice Thrown when a stake version upgrade targets an invalid version
-    /// @dev Target version must be strictly greater than current and not exceed the epoch-active version
+    /// @dev Target version must be strictly greater than current and not exceed global `stakeVersion`
     /// @param currentVersion The validator's current stake version
     /// @param targetVersion The requested target version that was rejected
     error InvalidStakeVersion(uint8 currentVersion, uint8 targetVersion);
@@ -152,15 +152,19 @@ interface IStakeManager {
     /// @dev Returns staking information for the given address
     function getBalanceBreakdown(address validatorAddress) external view returns (uint256, uint256, uint256);
 
-    /// @dev Returns the stake version active for the current epoch
-    /// @notice Versions configured mid-epoch remain pending until stamped in at the next epoch
+    /// @dev Returns the stake version active for the current epoch, ie the version stamped
+    /// into the epoch's info at its start
+    /// @notice Differs from `getCurrentStakeConfig` during any epoch in which governance has
+    /// authored a new version, since newly authored versions activate at the next epoch start
     function getCurrentStakeVersion() external view returns (uint8);
 
     /// @dev Returns the queried stake configuration
     function stakeConfig(uint8 version) external view returns (StakeConfig memory);
 
-    /// @dev Returns the stake configuration active for the current epoch
-    /// @notice Always agrees with `getCurrentStakeVersion`, ie `stakeConfig(getCurrentStakeVersion())`
+    /// @dev Returns the latest authored stake configuration, which becomes active at the
+    /// next epoch start
+    /// @notice Not necessarily the epoch-active config: during any epoch in which governance
+    /// has authored a new version, this differs from `stakeConfig(getCurrentStakeVersion())`
     function getCurrentStakeConfig() external view returns (StakeConfig memory);
 
     /// @dev Permissioned function to upgrade stake, withdrawal, and consensus block reward configurations
@@ -177,8 +181,6 @@ interface IStakeManager {
     /// Only callable for validators with status Staked, PendingActivation, or Active.
     /// @param validatorAddress The validator whose stake version should be upgraded
     /// @param targetVersion The new stake version to upgrade to (must be strictly greater than current)
-    /// @notice `targetVersion` must already be active for the current epoch; versions still
-    /// pending epoch activation cannot be adopted early
     /// @notice If the new version requires more stake, `msg.value` must equal the exact deficit
     /// @notice If the new version requires less stake, the surplus is refunded to the reward recipient.
     /// For partially slashed validators, only the balance above `newStakeAmount` is refunded.

--- a/src/interfaces/IStakeManager.sol
+++ b/src/interfaces/IStakeManager.sol
@@ -85,7 +85,7 @@ interface IStakeManager {
     /// @notice Thrown when unstaking would reduce ConsensusNFT totalSupply to zero
     error InvalidSupply();
     /// @notice Thrown when a stake version upgrade targets an invalid version
-    /// @dev Target version must be strictly greater than current and not exceed global `stakeVersion`
+    /// @dev Target version must be strictly greater than current and not exceed the epoch-active version
     /// @param currentVersion The validator's current stake version
     /// @param targetVersion The requested target version that was rejected
     error InvalidStakeVersion(uint8 currentVersion, uint8 targetVersion);
@@ -152,13 +152,15 @@ interface IStakeManager {
     /// @dev Returns staking information for the given address
     function getBalanceBreakdown(address validatorAddress) external view returns (uint256, uint256, uint256);
 
-    /// @dev Returns the current version
+    /// @dev Returns the stake version active for the current epoch
+    /// @notice Versions configured mid-epoch remain pending until stamped in at the next epoch
     function getCurrentStakeVersion() external view returns (uint8);
 
     /// @dev Returns the queried stake configuration
     function stakeConfig(uint8 version) external view returns (StakeConfig memory);
 
-    /// @dev Returns the current stake configuration
+    /// @dev Returns the stake configuration active for the current epoch
+    /// @notice Always agrees with `getCurrentStakeVersion`, ie `stakeConfig(getCurrentStakeVersion())`
     function getCurrentStakeConfig() external view returns (StakeConfig memory);
 
     /// @dev Permissioned function to upgrade stake, withdrawal, and consensus block reward configurations
@@ -175,6 +177,8 @@ interface IStakeManager {
     /// Only callable for validators with status Staked, PendingActivation, or Active.
     /// @param validatorAddress The validator whose stake version should be upgraded
     /// @param targetVersion The new stake version to upgrade to (must be strictly greater than current)
+    /// @notice `targetVersion` must already be active for the current epoch; versions still
+    /// pending epoch activation cannot be adopted early
     /// @notice If the new version requires more stake, `msg.value` must equal the exact deficit
     /// @notice If the new version requires less stake, the surplus is refunded to the reward recipient.
     /// For partially slashed validators, only the balance above `newStakeAmount` is refunded.

--- a/test/consensus/ConsensusRegistryTest.t.sol
+++ b/test/consensus/ConsensusRegistryTest.t.sol
@@ -824,7 +824,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
-        _activateLatestStakeVersion();
 
         // validator1 is Active with version 0
         uint256 deficit = newStakeAmt - stakeAmount_;
@@ -851,7 +850,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
-        _activateLatestStakeVersion();
 
         uint256 recipientBalBefore = validator1.balance;
 
@@ -875,7 +873,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(stakeAmount_, minWithdrawAmount_ * 2, epochIssuance_, epochDuration_)
         );
-        _activateLatestStakeVersion();
 
         vm.prank(validator1);
         consensusRegistry.upgradeValidatorStakeVersion(validator1, newVersion);
@@ -902,8 +899,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
-
-        _activateLatestStakeVersion();
 
         uint256 deficit = newStakeAmt - stakeAmount_;
         vm.deal(validator5, deficit);
@@ -941,8 +936,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
-
-        _activateLatestStakeVersion();
 
         uint256 delegatorBalBefore = delegator.balance;
 
@@ -990,8 +983,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
-        _activateLatestStakeVersion();
-
         uint256 deficit = newStakeAmt - stakeAmount_;
         vm.deal(validator1, deficit);
 
@@ -1021,8 +1012,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
-        _activateLatestStakeVersion();
-
         uint256 recipientBalBefore = validator1.balance;
 
         vm.prank(validator1);
@@ -1040,8 +1029,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
-
-        _activateLatestStakeVersion();
 
         // Send wrong amount (too much)
         uint256 wrongAmount = newStakeAmt;
@@ -1109,8 +1096,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
-        _activateLatestStakeVersion();
-
         uint256 recipientBalBefore = validator1.balance;
         uint256 issuanceBalBefore = issuance.balance;
         uint256 registryBalBefore = address(consensusRegistry).balance;
@@ -1176,8 +1161,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
-        _activateLatestStakeVersion();
-
         uint256 recipientBalBefore = validator1.balance;
 
         vm.prank(validator1);
@@ -1226,8 +1209,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
-        _activateLatestStakeVersion();
-
         uint256 recipientBalBefore = validator1.balance;
 
         vm.prank(validator1);
@@ -1253,8 +1234,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
-
-        _activateLatestStakeVersion();
 
         uint256 deficit = newStakeAmt - stakeAmount_;
         vm.deal(validator1, deficit);
@@ -1309,8 +1288,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
-        _activateLatestStakeVersion();
-
         uint256 deficit = newStakeAmt - stakeAmount_;
         vm.deal(validator1, deficit);
         vm.prank(validator1);
@@ -1343,8 +1320,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(stakeAmount_, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
-        _activateLatestStakeVersion();
-
         // Pause contract via crOwner
         vm.prank(crOwner);
         consensusRegistry.pause();
@@ -1371,7 +1346,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(0, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
-        _activateLatestStakeVersion();
 
         uint256 recipientBalBefore = validator1.balance;
 
@@ -1397,8 +1371,6 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(v2StakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
         vm.stopPrank();
-        // one epoch flip activates both pending versions
-        _activateLatestStakeVersion();
 
         // Upgrade v0 -> v1
         uint256 deficit1 = v1StakeAmt - stakeAmount_;
@@ -1430,47 +1402,31 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         assertEq(bal2, v2StakeAmt);
     }
 
-    function testRevert_upgradeValidatorStakeVersion_versionNotEpochActive() public {
-        vm.prank(crOwner);
-        uint8 newVersion = consensusRegistry.upgradeStakeVersion(
-            StakeConfig(stakeAmount_, minWithdrawAmount_ * 2, epochIssuance_, epochDuration_)
-        );
-
-        // the new version has not been stamped into an epoch yet, so adoption reverts
-        vm.prank(validator1);
-        vm.expectRevert(abi.encodeWithSelector(IStakeManager.InvalidStakeVersion.selector, uint8(0), newVersion));
-        consensusRegistry.upgradeValidatorStakeVersion(validator1, newVersion);
-
-        // once an epoch concludes the version becomes epoch-active and adoptable
-        _activateLatestStakeVersion();
-        vm.prank(validator1);
-        consensusRegistry.upgradeValidatorStakeVersion(validator1, newVersion);
-        assertEq(consensusRegistry.getValidator(validator1).stakeVersion, newVersion);
-    }
-
-    function test_getCurrentStakeConfig_matchesEpochActiveVersion() public {
+    function test_stakeVersionGetters_divergeForPendingVersion() public {
         uint256 newStakeAmt = 2_000_000e18;
         vm.prank(crOwner);
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
-        // mid-epoch the new version is still pending: both getters reflect the old config
+        // mid-epoch the epoch-active version is unchanged, while the config getter already
+        // returns the newly authored configuration that activates at the next epoch start
         assertEq(consensusRegistry.getCurrentStakeVersion(), 0);
-        StakeConfig memory pending = consensusRegistry.getCurrentStakeConfig();
-        assertEq(pending.stakeAmount, stakeAmount_);
-        assertEq(pending.stakeAmount, consensusRegistry.stakeConfig(consensusRegistry.getCurrentStakeVersion()).stakeAmount);
+        assertEq(consensusRegistry.getCurrentStakeConfig().stakeAmount, newStakeAmt);
 
-        // after the epoch flip both getters reflect the new version together
-        _activateLatestStakeVersion();
+        // at the next epoch start the authored version is stamped in and the getters agree
+        vm.prank(sysAddress);
+        consensusRegistry.concludeEpoch(_createTokenIdCommittee(4));
         assertEq(consensusRegistry.getCurrentStakeVersion(), newVersion);
-        StakeConfig memory active = consensusRegistry.getCurrentStakeConfig();
-        assertEq(active.stakeAmount, newStakeAmt);
-        assertEq(active.stakeAmount, consensusRegistry.stakeConfig(consensusRegistry.getCurrentStakeVersion()).stakeAmount);
+        assertEq(consensusRegistry.getCurrentStakeConfig().stakeAmount, newStakeAmt);
+        assertEq(
+            consensusRegistry.getCurrentStakeConfig().stakeAmount,
+            consensusRegistry.stakeConfig(consensusRegistry.getCurrentStakeVersion()).stakeAmount
+        );
     }
 
-    function test_getEpochInfo_futureEpochConfigUndefined() public {
-        // advance two epochs so both future slots have been rewritten by concludeEpoch
+    function test_getEpochInfo_futureEpochProjection() public {
+        // advance two epochs so both future ring buffer slots have been rewritten
         vm.startPrank(sysAddress);
         consensusRegistry.concludeEpoch(_createTokenIdCommittee(4));
         consensusRegistry.concludeEpoch(_createTokenIdCommittee(4));
@@ -1482,10 +1438,29 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             // committee and epoch id are known for future epochs
             assertEq(info.epochId, current + ahead);
             assertEq(info.committee.length, 4);
-            // configuration is undefined until the epoch begins, so all config fields are zero
-            assertEq(info.epochIssuance, 0);
-            assertEq(uint256(info.epochDuration), 0);
+            // config fields project the latest authored configuration (still genesis here)
+            assertEq(info.epochIssuance, epochIssuance_);
+            assertEq(uint256(info.epochDuration), uint256(epochDuration_));
             assertEq(uint256(info.stakeVersion), 0);
+            // block height is unknowable for future epochs
+            assertEq(uint256(info.blockHeight), 0);
+        }
+
+        // authoring a new version mid-epoch updates the projection immediately
+        uint256 newIssuance = epochIssuance_ * 2;
+        uint32 newDuration = epochDuration_ + 1;
+        vm.prank(crOwner);
+        uint8 newVersion = consensusRegistry.upgradeStakeVersion(
+            StakeConfig(2_000_000e18, minWithdrawAmount_, newIssuance, newDuration)
+        );
+
+        for (uint32 ahead = 1; ahead <= 2; ++ahead) {
+            EpochInfo memory info = consensusRegistry.getEpochInfo(current + ahead);
+            assertEq(info.epochId, current + ahead);
+            assertEq(info.committee.length, 4);
+            assertEq(info.epochIssuance, newIssuance);
+            assertEq(uint256(info.epochDuration), uint256(newDuration));
+            assertEq(uint256(info.stakeVersion), uint256(newVersion));
             assertEq(uint256(info.blockHeight), 0);
         }
     }

--- a/test/consensus/ConsensusRegistryTest.t.sol
+++ b/test/consensus/ConsensusRegistryTest.t.sol
@@ -824,6 +824,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
+        _activateLatestStakeVersion();
 
         // validator1 is Active with version 0
         uint256 deficit = newStakeAmt - stakeAmount_;
@@ -850,6 +851,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
+        _activateLatestStakeVersion();
 
         uint256 recipientBalBefore = validator1.balance;
 
@@ -873,6 +875,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(stakeAmount_, minWithdrawAmount_ * 2, epochIssuance_, epochDuration_)
         );
+        _activateLatestStakeVersion();
 
         vm.prank(validator1);
         consensusRegistry.upgradeValidatorStakeVersion(validator1, newVersion);
@@ -899,6 +902,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
+
+        _activateLatestStakeVersion();
 
         uint256 deficit = newStakeAmt - stakeAmount_;
         vm.deal(validator5, deficit);
@@ -936,6 +941,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
+
+        _activateLatestStakeVersion();
 
         uint256 delegatorBalBefore = delegator.balance;
 
@@ -983,6 +990,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
+        _activateLatestStakeVersion();
+
         uint256 deficit = newStakeAmt - stakeAmount_;
         vm.deal(validator1, deficit);
 
@@ -1012,6 +1021,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
+        _activateLatestStakeVersion();
+
         uint256 recipientBalBefore = validator1.balance;
 
         vm.prank(validator1);
@@ -1029,6 +1040,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
+
+        _activateLatestStakeVersion();
 
         // Send wrong amount (too much)
         uint256 wrongAmount = newStakeAmt;
@@ -1096,6 +1109,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
+        _activateLatestStakeVersion();
+
         uint256 recipientBalBefore = validator1.balance;
         uint256 issuanceBalBefore = issuance.balance;
         uint256 registryBalBefore = address(consensusRegistry).balance;
@@ -1161,6 +1176,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
+        _activateLatestStakeVersion();
+
         uint256 recipientBalBefore = validator1.balance;
 
         vm.prank(validator1);
@@ -1209,6 +1226,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
+        _activateLatestStakeVersion();
+
         uint256 recipientBalBefore = validator1.balance;
 
         vm.prank(validator1);
@@ -1234,6 +1253,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
+
+        _activateLatestStakeVersion();
 
         uint256 deficit = newStakeAmt - stakeAmount_;
         vm.deal(validator1, deficit);
@@ -1288,6 +1309,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
+        _activateLatestStakeVersion();
+
         uint256 deficit = newStakeAmt - stakeAmount_;
         vm.deal(validator1, deficit);
         vm.prank(validator1);
@@ -1320,6 +1343,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(stakeAmount_, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
 
+        _activateLatestStakeVersion();
+
         // Pause contract via crOwner
         vm.prank(crOwner);
         consensusRegistry.pause();
@@ -1346,6 +1371,7 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
         uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(0, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
+        _activateLatestStakeVersion();
 
         uint256 recipientBalBefore = validator1.balance;
 
@@ -1371,6 +1397,8 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
             StakeConfig(v2StakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
         vm.stopPrank();
+        // one epoch flip activates both pending versions
+        _activateLatestStakeVersion();
 
         // Upgrade v0 -> v1
         uint256 deficit1 = v1StakeAmt - stakeAmount_;
@@ -1400,6 +1428,66 @@ contract ConsensusRegistryTest is ConsensusRegistryTestUtils {
 
         // Check total balance equals v2 stake amount
         assertEq(bal2, v2StakeAmt);
+    }
+
+    function testRevert_upgradeValidatorStakeVersion_versionNotEpochActive() public {
+        vm.prank(crOwner);
+        uint8 newVersion = consensusRegistry.upgradeStakeVersion(
+            StakeConfig(stakeAmount_, minWithdrawAmount_ * 2, epochIssuance_, epochDuration_)
+        );
+
+        // the new version has not been stamped into an epoch yet, so adoption reverts
+        vm.prank(validator1);
+        vm.expectRevert(abi.encodeWithSelector(IStakeManager.InvalidStakeVersion.selector, uint8(0), newVersion));
+        consensusRegistry.upgradeValidatorStakeVersion(validator1, newVersion);
+
+        // once an epoch concludes the version becomes epoch-active and adoptable
+        _activateLatestStakeVersion();
+        vm.prank(validator1);
+        consensusRegistry.upgradeValidatorStakeVersion(validator1, newVersion);
+        assertEq(consensusRegistry.getValidator(validator1).stakeVersion, newVersion);
+    }
+
+    function test_getCurrentStakeConfig_matchesEpochActiveVersion() public {
+        uint256 newStakeAmt = 2_000_000e18;
+        vm.prank(crOwner);
+        uint8 newVersion = consensusRegistry.upgradeStakeVersion(
+            StakeConfig(newStakeAmt, minWithdrawAmount_, epochIssuance_, epochDuration_)
+        );
+
+        // mid-epoch the new version is still pending: both getters reflect the old config
+        assertEq(consensusRegistry.getCurrentStakeVersion(), 0);
+        StakeConfig memory pending = consensusRegistry.getCurrentStakeConfig();
+        assertEq(pending.stakeAmount, stakeAmount_);
+        assertEq(pending.stakeAmount, consensusRegistry.stakeConfig(consensusRegistry.getCurrentStakeVersion()).stakeAmount);
+
+        // after the epoch flip both getters reflect the new version together
+        _activateLatestStakeVersion();
+        assertEq(consensusRegistry.getCurrentStakeVersion(), newVersion);
+        StakeConfig memory active = consensusRegistry.getCurrentStakeConfig();
+        assertEq(active.stakeAmount, newStakeAmt);
+        assertEq(active.stakeAmount, consensusRegistry.stakeConfig(consensusRegistry.getCurrentStakeVersion()).stakeAmount);
+    }
+
+    function test_getEpochInfo_futureEpochConfigUndefined() public {
+        // advance two epochs so both future slots have been rewritten by concludeEpoch
+        vm.startPrank(sysAddress);
+        consensusRegistry.concludeEpoch(_createTokenIdCommittee(4));
+        consensusRegistry.concludeEpoch(_createTokenIdCommittee(4));
+        vm.stopPrank();
+
+        uint32 current = consensusRegistry.getCurrentEpoch();
+        for (uint32 ahead = 1; ahead <= 2; ++ahead) {
+            EpochInfo memory info = consensusRegistry.getEpochInfo(current + ahead);
+            // committee and epoch id are known for future epochs
+            assertEq(info.epochId, current + ahead);
+            assertEq(info.committee.length, 4);
+            // configuration is undefined until the epoch begins, so all config fields are zero
+            assertEq(info.epochIssuance, 0);
+            assertEq(uint256(info.epochDuration), 0);
+            assertEq(uint256(info.stakeVersion), 0);
+            assertEq(uint256(info.blockHeight), 0);
+        }
     }
 
     function test_delegatedValidator_voluntaryExit_clearedDelegation() public {

--- a/test/consensus/ConsensusRegistryTestUtils.sol
+++ b/test/consensus/ConsensusRegistryTestUtils.sol
@@ -438,24 +438,11 @@ contract ConsensusRegistryTestUtils is ConsensusRegistry, GenesisPrecompiler, Bl
         return (rewardInfos, expectedRewards);
     }
 
-    /// @dev Concludes one epoch with a placeholder committee so the most recently configured
-    /// stake version becomes epoch-active and adoptable via `upgradeValidatorStakeVersion`
-    function _activateLatestStakeVersion() internal {
-        uint256 committeeSize = consensusRegistry.getNextCommitteeSize();
-        vm.prank(sysAddress);
-        consensusRegistry.concludeEpoch(_createTokenIdCommittee(committeeSize));
-    }
-
     function _fuzz_upgradeGlobalStakeVersion(uint256 newStakeAmount) internal returns (uint8) {
         vm.prank(crOwner);
-        uint8 newVersion = consensusRegistry.upgradeStakeVersion(
+        return consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmount, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
-        // new configs activate at the next epoch boundary; conclude one epoch so the
-        // version is immediately adoptable in tests
-        _activateLatestStakeVersion();
-
-        return newVersion;
     }
 
     function _fuzz_upgradeValidatorStakeVersions(

--- a/test/consensus/ConsensusRegistryTestUtils.sol
+++ b/test/consensus/ConsensusRegistryTestUtils.sol
@@ -438,11 +438,24 @@ contract ConsensusRegistryTestUtils is ConsensusRegistry, GenesisPrecompiler, Bl
         return (rewardInfos, expectedRewards);
     }
 
+    /// @dev Concludes one epoch with a placeholder committee so the most recently configured
+    /// stake version becomes epoch-active and adoptable via `upgradeValidatorStakeVersion`
+    function _activateLatestStakeVersion() internal {
+        uint256 committeeSize = consensusRegistry.getNextCommitteeSize();
+        vm.prank(sysAddress);
+        consensusRegistry.concludeEpoch(_createTokenIdCommittee(committeeSize));
+    }
+
     function _fuzz_upgradeGlobalStakeVersion(uint256 newStakeAmount) internal returns (uint8) {
         vm.prank(crOwner);
-        return consensusRegistry.upgradeStakeVersion(
+        uint8 newVersion = consensusRegistry.upgradeStakeVersion(
             StakeConfig(newStakeAmount, minWithdrawAmount_, epochIssuance_, epochDuration_)
         );
+        // new configs activate at the next epoch boundary; conclude one epoch so the
+        // version is immediately adoptable in tests
+        _activateLatestStakeVersion();
+
+        return newVersion;
     }
 
     function _fuzz_upgradeValidatorStakeVersions(


### PR DESCRIPTION
## Findings

Two low-severity Cantina items, bundled into one PR per the one-PR-for-Lows rule. A third Low (early adoption of pending stake versions via `upgradeValidatorStakeVersion`) is addressed separately as an accepted finding and is intentionally not changed here.

### Future epoch information contains unknown configuration fields (`getEpochInfo`)

`_updateEpochInfo` wrote only `committee` and `epochId` into the two-epochs-ahead ring buffer slot, so `getEpochInfo` for future epochs returned whatever issuance/duration/stakeVersion the slot held from four epochs prior - in practice the genesis-seeded values, stale forever after any version upgrade.

Storage now carries only what is genuinely known ahead of time: future slots are written with the committee and epoch id alone (config fields and block height zeroed, constructor seeding removed). At read time, `getEpochInfo` overlays a projection for future epochs: `epochIssuance`, `epochDuration`, and `stakeVersion` are filled from the latest authored configuration - the values the epoch would be stamped with if it began now. The projection can change until the epoch is stamped at its start, and `blockHeight` stays 0 since it is unknowable. `getCommitteeValidators` and `getCommitteeBlsPubkeys` read only `.committee`, so the overlay is inert for them.

### Current stake version and config getters can transiently disagree (documented intent)

`getCurrentStakeVersion()` and `getCurrentStakeConfig()` intentionally answer different questions, and only the naming suggests otherwise. The version getter returns the version stamped into the current epoch at its start (the epoch-active version). The config getter returns the latest authored configuration, which becomes active at the next epoch start - it is exactly what `concludeEpoch` stamps into each new epoch via `_updateEpochInfo`, its only in-contract consumer. The two therefore differ during any epoch in which governance has authored a new version, by design.

Both getters keep their names and behavior (the ABI is consumed externally); this PR adds explicit natspec on both interface declarations and implementations stating the epoch-active vs latest-authored distinction and when the two diverge.

## Tests

- `test_getEpochInfo_futureEpochProjection`: future epochs report the correct committee and epoch id; config fields reflect the latest authored configuration and update immediately when a new version is authored mid-epoch; `blockHeight` is 0. Fails against the prior implementation.
- `test_stakeVersionGetters_divergeForPendingVersion`: pins the intended divergence - after a mid-epoch `upgradeStakeVersion`, `getCurrentStakeVersion()` is unchanged while `getCurrentStakeConfig()` returns the new config; the getters agree again once the epoch concludes.

Full suite: 220 passed, 0 failed, 2 skipped.

Closes #151.
Closes #155.
